### PR TITLE
Add IUT monitoring commands for ETR

### DIFF
--- a/src/etos_test_runner/lib/iut.py
+++ b/src/etos_test_runner/lib/iut.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -16,9 +16,11 @@
 """IUT data structure module."""
 import os
 import logging
+from pathlib import Path
 from collections import OrderedDict
 from packageurl import PackageURL
 from jsontas.jsontas import JsonTas
+from etos_lib.lib.config import Config
 
 
 class Iut:  # pylint: disable=too-few-public-methods
@@ -34,7 +36,12 @@ class Iut:  # pylint: disable=too-few-public-methods
         :type product: dict
         """
         self.test_runner = {}
-        self.steps = {"environment": self.load_environment}
+        self.config = Config()
+        self.config.set("scripts", [])
+        self.steps = {
+            "environment": self.load_environment,
+            "commands": self.commands
+        }
 
         product["identity"] = PackageURL.from_string(product["identity"])
         for key, value in product.items():
@@ -55,9 +62,16 @@ class Iut:  # pylint: disable=too-few-public-methods
                 )
                 continue
             self.logger.info("Executing step %r", step)
-            definition = OrderedDict(**definition)
-            step_result = self.jsontas.run(json_data=definition)
-            step_method(step_result)
+            self.logger.info("Definition: %r", definition)
+            if isinstance(definition, list):
+                for sub_definition in definition:
+                    sub_definition = OrderedDict(**sub_definition)
+                    step_result = self.jsontas.run(json_data=sub_definition)
+                    step_method(step_result)
+            else:
+                definition = OrderedDict(**definition)
+                step_result = self.jsontas.run(json_data=definition)
+                step_method(step_result)
 
     @staticmethod
     def load_environment(environment):
@@ -68,6 +82,19 @@ class Iut:  # pylint: disable=too-few-public-methods
         """
         for key, value in environment.items():
             os.environ[key] = value
+
+    def commands(self, command):
+        """Create scripts from commands and add them to IUT monitoring.
+
+        :param command: A command dictionary to prepare.
+        :type command: dict
+        """
+        script_name = str(Path.cwd().joinpath(command.get("name")))
+        parameters = command.get("parameters", [])
+        with open(script_name, "w") as script:
+            for line in command.get("script"):
+                script.write("{}\n".format(line))
+        self.config.get("scripts").append({"name": script_name, "parameters": parameters})
 
     @property
     def as_dict(self):

--- a/src/etos_test_runner/lib/iut.py
+++ b/src/etos_test_runner/lib/iut.py
@@ -90,7 +90,7 @@ class Iut:  # pylint: disable=too-few-public-methods
         parameters = command.get("parameters", [])
         with open(script_name, "w") as script:
             for line in command.get("script"):
-                script.write("{}\n".format(line))
+                script.write(f"{line}\n")
         self.config.get("scripts").append(
             {"name": script_name, "parameters": parameters}
         )

--- a/src/etos_test_runner/lib/iut.py
+++ b/src/etos_test_runner/lib/iut.py
@@ -38,10 +38,7 @@ class Iut:  # pylint: disable=too-few-public-methods
         self.test_runner = {}
         self.config = Config()
         self.config.set("scripts", [])
-        self.steps = {
-            "environment": self.load_environment,
-            "commands": self.commands
-        }
+        self.steps = {"environment": self.load_environment, "commands": self.commands}
 
         product["identity"] = PackageURL.from_string(product["identity"])
         for key, value in product.items():
@@ -94,7 +91,9 @@ class Iut:  # pylint: disable=too-few-public-methods
         with open(script_name, "w") as script:
             for line in command.get("script"):
                 script.write("{}\n".format(line))
-        self.config.get("scripts").append({"name": script_name, "parameters": parameters})
+        self.config.get("scripts").append(
+            {"name": script_name, "parameters": parameters}
+        )
 
     @property
     def as_dict(self):

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -200,34 +200,34 @@ class TestRunner:
 
         result = True
         description = None
-        with Workspace(self.log_area) as workspace:
-            self.logger.info("Start IUT monitoring.")
-            self.iut_monitoring.start_monitoring()
-            try:
+        try:
+            with Workspace(self.log_area) as workspace:
+                self.logger.info("Start IUT monitoring.")
+                self.iut_monitoring.start_monitoring()
                 self.logger.info("Starting test executor.")
                 result = self.run_tests(workspace)
                 executed = True
-            except Exception as exception:  # pylint:disable=broad-except
-                result = False
-                executed = False
-                description = str(exception)
-                raise
-            finally:
-                self.logger.info("Stop IUT monitoring.")
-                self.iut_monitoring.stop_monitoring()
+        except Exception as exception:  # pylint:disable=broad-except
+            result = False
+            executed = False
+            description = str(exception)
+            raise
+        finally:
+            self.logger.info("Stop IUT monitoring.")
+            self.iut_monitoring.stop_monitoring()
 
-                self.logger.info("Figure out test outcome.")
-                outcome = self.outcome(result, executed, description)
-                pprint(outcome)
+            self.logger.info("Figure out test outcome.")
+            outcome = self.outcome(result, executed, description)
+            pprint(outcome)
 
-                self.logger.info("Send test suite finished and confidence events.")
-                self.etos.events.send_test_suite_finished(
-                    test_suite_started,
-                    links={"CONTEXT": self.etos.config.get("context")},
-                    outcome=outcome,
-                    persistentLogs=self.log_area.persistent_logs,
-                )
-                self.confidence_level(result, test_suite_started)
+            self.logger.info("Send test suite finished and confidence events.")
+            self.etos.events.send_test_suite_finished(
+                test_suite_started,
+                links={"CONTEXT": self.etos.config.get("context")},
+                outcome=outcome,
+                persistentLogs=self.log_area.persistent_logs,
+            )
+            self.confidence_level(result, test_suite_started)
         timeout = time.time() + 30
         self.logger.info("Waiting for eiffel publisher to deliver events (30s).")
         # pylint:disable=len-as-condition, protected-access

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -113,24 +113,25 @@ class TestRunner:
                 host={"name": os.getenv("HOSTNAME"), "user": "etos"},
             )
 
-    def run_tests(self):
+    def run_tests(self, workspace):
         """Execute test recipes within a test executor.
 
+        :param workspace: Which workspace to execute test suite within.
+        :type workspace: :obj:`etr.lib.workspace.Workspace`
         :return: Result of test execution.
         :rtype: bool
         """
         recipes = self.config.get("recipes")
         result = True
-        with Workspace(self.log_area) as workspace:
-            for num, test in enumerate(recipes):
-                self.logger.info("Executing test %s/%s", num + 1, len(recipes))
-                with Executor(test, self.iut, self.etos) as executor:
-                    self.logger.info("Starting test '%s'", executor.test_name)
-                    executor.execute(workspace)
+        for num, test in enumerate(recipes):
+            self.logger.info("Executing test %s/%s", num + 1, len(recipes))
+            with Executor(test, self.iut, self.etos) as executor:
+                self.logger.info("Starting test '%s'", executor.test_name)
+                executor.execute(workspace)
 
-                    if not executor.result:
-                        result = executor.result
-                    self.logger.info("Test finished. Result: %s.", executor.result)
+                if not executor.result:
+                    result = executor.result
+                self.logger.info("Test finished. Result: %s.", executor.result)
         return result
 
     def outcome(self, result, executed, description):
@@ -197,36 +198,37 @@ class TestRunner:
         self.etos.config.set("main_suite_id", main_suite_id)
         self.etos.config.set("sub_suite_id", sub_suite_id)
 
-        self.logger.info("Start IUT monitoring.")
-        self.iut_monitoring.start_monitoring()
 
         result = True
         description = None
-        try:
-            self.logger.info("Starting test executor.")
-            result = self.run_tests()
-            executed = True
-        except Exception as exception:  # pylint:disable=broad-except
-            result = False
-            executed = False
-            description = str(exception)
-            raise
-        finally:
-            self.logger.info("Stop IUT monitoring.")
-            self.iut_monitoring.stop_monitoring()
+        with Workspace(self.log_area) as workspace:
+            self.logger.info("Start IUT monitoring.")
+            self.iut_monitoring.start_monitoring()
+            try:
+                self.logger.info("Starting test executor.")
+                result = self.run_tests(workspace)
+                executed = True
+            except Exception as exception:  # pylint:disable=broad-except
+                result = False
+                executed = False
+                description = str(exception)
+                raise
+            finally:
+                self.logger.info("Stop IUT monitoring.")
+                self.iut_monitoring.stop_monitoring()
 
-            self.logger.info("Figure out test outcome.")
-            outcome = self.outcome(result, executed, description)
-            pprint(outcome)
+                self.logger.info("Figure out test outcome.")
+                outcome = self.outcome(result, executed, description)
+                pprint(outcome)
 
-            self.logger.info("Send test suite finished and confidence events.")
-            self.etos.events.send_test_suite_finished(
-                test_suite_started,
-                links={"CONTEXT": self.etos.config.get("context")},
-                outcome=outcome,
-                persistentLogs=self.log_area.persistent_logs,
-            )
-            self.confidence_level(result, test_suite_started)
+                self.logger.info("Send test suite finished and confidence events.")
+                self.etos.events.send_test_suite_finished(
+                    test_suite_started,
+                    links={"CONTEXT": self.etos.config.get("context")},
+                    outcome=outcome,
+                    persistentLogs=self.log_area.persistent_logs,
+                )
+                self.confidence_level(result, test_suite_started)
         timeout = time.time() + 30
         self.logger.info("Waiting for eiffel publisher to deliver events (30s).")
         # pylint:disable=len-as-condition, protected-access

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -198,7 +198,6 @@ class TestRunner:
         self.etos.config.set("main_suite_id", main_suite_id)
         self.etos.config.set("sub_suite_id", sub_suite_id)
 
-
         result = True
         description = None
         with Workspace(self.log_area) as workspace:

--- a/src/etos_test_runner/lib/workspace.py
+++ b/src/etos_test_runner/lib/workspace.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -41,7 +41,9 @@ class Workspace:
         self.identifiers = {}
 
         self.global_logs = self.top_dir.joinpath("logs")
+        self.global_artifacts = self.top_dir.joinpath("artifacts")
         environ["GLOBAL_LOGS"] = str(self.global_logs)
+        environ["GLOBAL_ARTIFACTS"] = str(self.global_artifacts)
 
     def __enter__(self, path=None):
         """Create and chdir to a workspace."""
@@ -51,6 +53,7 @@ class Workspace:
         )
         self.workspace.mkdir(exist_ok=True)
         self.global_logs.mkdir(exist_ok=True)
+        self.global_artifacts.mkdir(exist_ok=True)
         self.logger.info(
             "Changing directory to workspace %r",
             self.workspace.relative_to(self.top_dir),
@@ -64,6 +67,7 @@ class Workspace:
         chdir(self.top_dir)
         self.compress()
         self.log_area.upload_logs(self.log_area.collect(self.global_logs))
+        self.log_area.upload_artifacts(self.log_area.collect(self.global_artifacts))
         self.log_area.upload_artifacts(
             [
                 {

--- a/tests/lib/test_iut_monitoring.py
+++ b/tests/lib/test_iut_monitoring.py
@@ -1,0 +1,418 @@
+# Copyright 2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""IUT monitoring test module."""
+import os
+import sys
+import logging
+import time
+from pathlib import Path
+from unittest import TestCase
+from etos_lib.lib.config import Config
+from etos_test_runner.lib.iut_monitoring import IutMonitoring
+
+logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+
+
+class TestIutMonitoring(TestCase):
+    """Tests for the IUT monitoring library."""
+
+    logger = logging.getLogger(__name__)
+    script = Path.cwd().joinpath("script.sh")
+
+    def setUp(self):
+        """Create a script file."""
+        script = ["#!/bin/bash", "cat > $(pwd)/output << EOF", "Hello $1", "EOF"]
+        with open(self.script, "w") as scriptfile:
+            for line in script:
+                scriptfile.write(f"{line}\n")
+        self.config = Config()
+        self.files = [self.script, Path.cwd().joinpath("output")]
+
+    def tearDown(self):
+        """Remove script file."""
+        for script in self.files:
+            self.logger.debug("Removing %r", script)
+            try:
+                script.unlink()
+            except FileNotFoundError:
+                pass
+        self.config.set("scripts", [])
+
+    def _wait_for_file(self, filename, timeout=5):
+        """Wait for a file to exist.
+
+        :param filename: Absolute path to file.
+        :type filename: str
+        :param timeout: Maximum time to wait for file to exist. In seconds.
+        :type timeout: int
+        :return: True if the file exists, False if it does not.
+        :rtype: bool
+        """
+        end = time.time() + timeout
+        while time.time() < end:
+            # Sleep is done before checking if the file exists.
+            # This adds 1 second to all tests that utilize this method, but
+            # it will assist with race conditions when the script writes to
+            # file. I.e. the file can exist, but no data in it yet.
+            time.sleep(1)
+            if os.path.exists(filename):
+                return True
+        self.logger.warning("File did not exist after %r seconds.", timeout)
+        return False
+
+    def test_start_monitoring_single_script(self):
+        """Verify that the start monitoring method can execute a single script.
+
+        Approval criteria:
+            - Start monitoring shall execute a script to completion.
+
+        Test steps::
+            1. Initialize IUT monitoring.
+            2. Load a script to the config.
+            3. Start monitoring.
+            4. Verify that the script executed.
+        """
+        self.logger.info("STEP: Initialize IUT monitoring.")
+        iut_monitoring = IutMonitoring(None)
+
+        self.logger.info("STEP: Load script to the config.")
+        self.config.set(
+            "scripts", [{"name": str(self.script), "parameters": ["world"]}]
+        )
+
+        self.logger.info("STEP: Start monitoring.")
+        iut_monitoring.start_monitoring()
+
+        self.logger.info("STEP: Verify that the script executed.")
+        self._wait_for_file(Path.cwd().joinpath("output"))
+        with open(Path.cwd().joinpath("output")) as output:
+            hello_world = output.read().strip()
+            self.logger.info(hello_world)
+        self.assertEqual(hello_world, "Hello world")
+
+    def test_start_monitoring_multiple_scripts(self):
+        """Verify that the start monitoring method can execute multiple scripts.
+
+        Approval criteria:
+            - Start monitoring shall execute multiple scripts to completion.
+
+        Test steps::
+            1. Initialize IUT monitoring.
+            2. Load the scripts to the config.
+            3. Start monitoring.
+            4. Verify that the scripts executed.
+        """
+        self.logger.info("STEP: Initialize IUT monitoring.")
+        iut_monitoring = IutMonitoring(None)
+
+        self.logger.info("STEP: Load the scripts to the config.")
+        script = ["#!/bin/bash", "cat > $(pwd)/output2 << EOF", "Goodbye $1", "EOF"]
+        second_script = Path.cwd().joinpath("second.sh")
+        self.files.append(second_script)
+        self.files.append(Path.cwd().joinpath("output2"))
+        with open(second_script, "w") as scriptfile:
+            for line in script:
+                scriptfile.write(f"{line}\n")
+        self.config.set(
+            "scripts",
+            [
+                {"name": str(self.script), "parameters": ["world"]},
+                {"name": str(second_script), "parameters": ["world"]},
+            ],
+        )
+
+        self.logger.info("STEP: Start monitoring.")
+        iut_monitoring.start_monitoring()
+
+        self.logger.info("STEP: Verify that the scripts executed.")
+        self._wait_for_file(Path.cwd().joinpath("output"))
+        with open(Path.cwd().joinpath("output")) as output:
+            hello_world = output.read().strip()
+            self.logger.info(hello_world)
+        self._wait_for_file(Path.cwd().joinpath("output2"))
+        with open(Path.cwd().joinpath("output2")) as output:
+            goodbye_world = output.read().strip()
+            self.logger.info(goodbye_world)
+        self.assertEqual(hello_world, "Hello world")
+        self.assertEqual(goodbye_world, "Goodbye world")
+
+    def test_stop_monitoring_single_script(self):
+        """Verify that stop monitoring a single script interrupt it.
+
+        Approval criteria:
+            - stop monitoring shall send SIGINT to process.
+
+        Test steps::
+            1. Initialize IUT monitoring.
+            2. Create and add a script with an infinite loop.
+            3. Start monitoring.
+            4. Stop monitoring.
+            5. Verify that the script was interrupted with SIGINT.
+        """
+        self.logger.info("STEP: Initialize IUT monitoring.")
+        iut_monitoring = IutMonitoring(None)
+
+        self.logger.info("STEP: Create and add a script with an infinite loop.")
+        script = [
+            "#!/bin/bash",
+            "int_handler() {",
+            "   cat > $(pwd)/output << EOF",
+            "interrupted!",
+            "EOF",
+            "   exit 0",
+            "}",
+            "trap int_handler INT",
+            "while :",
+            "do",
+            "   sleep 1",
+            "done",
+        ]
+        interrupt_script = Path.cwd().joinpath("interrupt.sh")
+        self.files.append(interrupt_script)
+        self.files.append(Path.cwd().joinpath("output"))
+        with open(interrupt_script, "w") as scriptfile:
+            for line in script:
+                scriptfile.write(f"{line}\n")
+        self.config.set(
+            "scripts",
+            [
+                {"name": str(interrupt_script)},
+            ],
+        )
+
+        self.logger.info("STEP: Start monitoring.")
+        iut_monitoring.start_monitoring()
+        time.sleep(1)
+
+        self.logger.info("STEP: Stop monitoring.")
+        iut_monitoring.stop_monitoring()
+
+        self.logger.info("STEP: Verify that the script was interrupted with SIGINT.")
+        self.assertTrue(self._wait_for_file(Path.cwd().joinpath("output")))
+        with open(Path.cwd().joinpath("output")) as output:
+            text = output.read().strip()
+        self.assertEqual(text, "interrupted!")
+
+    def test_stop_monitoring_multiple_scripts(self):
+        """Verify that stop monitoring multiple scripts interrupts them.
+
+        Approval criteria:
+            - stop monitoring shall send SIGINT to all processes.
+
+        Test steps::
+            1. Initialize IUT monitoring.
+            2. Create and add multiple scripts with an infinite loop.
+            3. Start monitoring.
+            4. Stop monitoring.
+            5. Verify that the scripts were interrupted with SIGINT.
+        """
+        self.logger.info("STEP: Initialize IUT monitoring.")
+        iut_monitoring = IutMonitoring(None)
+
+        self.logger.info("STEP: Create and add multiple scripts with an infinite loop.")
+        script = [
+            "#!/bin/bash",
+            "int_handler() {",
+            "   cat > $(pwd)/output << EOF",
+            "interrupted!",
+            "EOF",
+            "   exit 0",
+            "}",
+            "trap int_handler INT",
+            "while :",
+            "do",
+            "   sleep 1",
+            "done",
+        ]
+        first_interrupt_script = Path.cwd().joinpath("first_interrupt.sh")
+        self.files.append(first_interrupt_script)
+        self.files.append(Path.cwd().joinpath("output"))
+        with open(first_interrupt_script, "w") as scriptfile:
+            for line in script:
+                scriptfile.write(f"{line}\n")
+        script = [
+            "#!/bin/bash",
+            "int_handler() {",
+            "   cat > $(pwd)/output2 << EOF",
+            "interrupted!",
+            "EOF",
+            "   exit 0",
+            "}",
+            "trap int_handler INT",
+            "while :",
+            "do",
+            "   sleep 1",
+            "done",
+        ]
+        second_interrupt_script = Path.cwd().joinpath("second_interrupt.sh")
+        self.files.append(second_interrupt_script)
+        self.files.append(Path.cwd().joinpath("output2"))
+        with open(second_interrupt_script, "w") as scriptfile:
+            for line in script:
+                scriptfile.write(f"{line}\n")
+        self.config.set(
+            "scripts",
+            [
+                {"name": str(first_interrupt_script)},
+                {"name": str(second_interrupt_script)},
+            ],
+        )
+
+        self.logger.info("STEP: Start monitoring.")
+        iut_monitoring.start_monitoring()
+        time.sleep(1)
+
+        self.logger.info("STEP: Stop monitoring.")
+        iut_monitoring.stop_monitoring()
+
+        self.logger.info("STEP: Verify that the scripts were interrupted with SIGINT.")
+        self.assertTrue(self._wait_for_file(Path.cwd().joinpath("output")))
+        self.assertTrue(self._wait_for_file(Path.cwd().joinpath("output2")))
+        with open(Path.cwd().joinpath("output")) as output:
+            text = output.read().strip()
+        self.assertEqual(text, "interrupted!")
+        with open(Path.cwd().joinpath("output2")) as output:
+            text = output.read().strip()
+        self.assertEqual(text, "interrupted!")
+
+    def test_stop_monitoring_terminate(self):
+        """Verify that stop monitoring will attempt to terminate script that does not interrupt.
+
+        Approval criteria:
+            - stop monitoring shall send SEGTERM to process if SIGINT fails.
+
+        Test steps::
+            1. Initialize IUT monitoring.
+            2. Create and add a script catching SIGINT.
+            3. Start monitoring.
+            4. Stop monitoring.
+            5. Verify that the script was interrupted with SIGTERM.
+        """
+        self.logger.info("STEP: Initialize IUT monitoring.")
+        iut_monitoring = IutMonitoring(None)
+        iut_monitoring.interrupt_timeout = 5
+        iut_monitoring.terminate_timeout = 5
+
+        self.logger.info("STEP: Create and add a script catching SIGINT.")
+        script = [
+            "#!/bin/bash",
+            "int_handler() {",
+            "   echo interrupted! > $(pwd)/output",
+            "}",
+            "term_handler() {",
+            "   echo terminated! >> $(pwd)/output",
+            "   exit 0",
+            "}",
+            "trap int_handler INT",
+            "trap term_handler TERM",
+            "while :",
+            "do",
+            "   sleep 1",
+            "done",
+        ]
+        interrupt_script = Path.cwd().joinpath("terminate.sh")
+        self.files.append(interrupt_script)
+        self.files.append(Path.cwd().joinpath("output"))
+        with open(interrupt_script, "w") as scriptfile:
+            for line in script:
+                scriptfile.write(f"{line}\n")
+        self.config.set(
+            "scripts",
+            [
+                {"name": str(interrupt_script)},
+            ],
+        )
+
+        self.logger.info("STEP: Start monitoring.")
+        iut_monitoring.start_monitoring()
+        time.sleep(1)
+
+        self.logger.info("STEP: Stop monitoring.")
+        iut_monitoring.stop_monitoring()
+
+        self.logger.info("STEP: Verify that the script was interrupted with SIGINT.")
+        self.assertTrue(self._wait_for_file(Path.cwd().joinpath("output")))
+        with open(Path.cwd().joinpath("output")) as output:
+            lines = output.readlines()
+        interrupt = lines.pop(0).strip()
+        self.assertEqual(interrupt, "interrupted!")
+        terminate = lines.pop(0).strip()
+        self.assertEqual(terminate, "terminated!")
+
+    def test_stop_monitoring_kill(self):
+        """Verify that stop monitoring will attempt to kill script that does not terminate.
+
+        Approval criteria:
+            - stop monitoring shall send SIGKILL to process if SIGTERM fails.
+
+        Test steps::
+            1. Initialize IUT monitoring.
+            2. Create and add a script catching SIGINT and SIGTERM.
+            3. Start monitoring.
+            4. Stop monitoring.
+            5. Verify that the script was killed.
+        """
+        self.logger.info("STEP: Initialize IUT monitoring.")
+        iut_monitoring = IutMonitoring(None)
+        iut_monitoring.interrupt_timeout = 5
+        iut_monitoring.terminate_timeout = 5
+
+        self.logger.info("STEP: Create and add a script catching SIGINT and SIGTERM.")
+        script = [
+            "#!/bin/bash",
+            "int_handler() {",
+            "   echo interrupted! > $(pwd)/output",
+            "}",
+            "term_handler() {",
+            "   echo terminated! >> $(pwd)/output",
+            "}",
+            "trap int_handler INT",
+            "trap term_handler TERM",
+            "while :",
+            "do",
+            "   sleep 1",
+            "done",
+        ]
+        interrupt_script = Path.cwd().joinpath("kill.sh")
+        self.files.append(interrupt_script)
+        self.files.append(Path.cwd().joinpath("output"))
+        with open(interrupt_script, "w") as scriptfile:
+            for line in script:
+                scriptfile.write(f"{line}\n")
+        self.config.set(
+            "scripts",
+            [
+                {"name": str(interrupt_script)},
+            ],
+        )
+
+        self.logger.info("STEP: Start monitoring.")
+        iut_monitoring.start_monitoring()
+        time.sleep(1)
+        process = iut_monitoring.processes[0]
+
+        self.logger.info("STEP: Stop monitoring.")
+        iut_monitoring.stop_monitoring()
+
+        self.logger.info("STEP: Verify that the script was killed.")
+        self.assertTrue(self._wait_for_file(Path.cwd().joinpath("output")))
+        with open(Path.cwd().joinpath("output")) as output:
+            lines = output.readlines()
+        interrupt = lines.pop(0).strip()
+        self.assertEqual(interrupt, "interrupted!")
+        terminate = lines.pop(0).strip()
+        self.assertEqual(terminate, "terminated!")
+        self.assertEqual(process.returncode, -9)

--- a/tests/lib/test_iut_monitoring.py
+++ b/tests/lib/test_iut_monitoring.py
@@ -34,7 +34,7 @@ class TestIutMonitoring(TestCase):
 
     def setUp(self):
         """Create a script file."""
-        script = ["#!/bin/bash", "cat > $(pwd)/output << EOF", "Hello $1", "EOF"]
+        script = ["#!/bin/bash", "echo Hello $1 > $(pwd)/output"]
         with open(self.script, "w") as scriptfile:
             for line in script:
                 scriptfile.write(f"{line}\n")
@@ -87,6 +87,9 @@ class TestIutMonitoring(TestCase):
         """
         self.logger.info("STEP: Initialize IUT monitoring.")
         iut_monitoring = IutMonitoring(None)
+        iut_monitoring.interrupt_timeout = 5
+        iut_monitoring.terminate_timeout = 5
+        iut_monitoring.kill_timeout = 5
 
         self.logger.info("STEP: Load script to the config.")
         self.config.set(
@@ -117,9 +120,12 @@ class TestIutMonitoring(TestCase):
         """
         self.logger.info("STEP: Initialize IUT monitoring.")
         iut_monitoring = IutMonitoring(None)
+        iut_monitoring.interrupt_timeout = 5
+        iut_monitoring.terminate_timeout = 5
+        iut_monitoring.kill_timeout = 5
 
         self.logger.info("STEP: Load the scripts to the config.")
-        script = ["#!/bin/bash", "cat > $(pwd)/output2 << EOF", "Goodbye $1", "EOF"]
+        script = ["#!/bin/bash", "echo Goodbye $1 > $(pwd)/output2"]
         second_script = Path.cwd().joinpath("second.sh")
         self.files.append(second_script)
         self.files.append(Path.cwd().joinpath("output2"))
@@ -164,14 +170,15 @@ class TestIutMonitoring(TestCase):
         """
         self.logger.info("STEP: Initialize IUT monitoring.")
         iut_monitoring = IutMonitoring(None)
+        iut_monitoring.interrupt_timeout = 5
+        iut_monitoring.terminate_timeout = 5
+        iut_monitoring.kill_timeout = 5
 
         self.logger.info("STEP: Create and add a script with an infinite loop.")
         script = [
             "#!/bin/bash",
             "int_handler() {",
-            "   cat > $(pwd)/output << EOF",
-            "interrupted!",
-            "EOF",
+            "   echo interrupted! > $(pwd)/output",
             "   exit 0",
             "}",
             "trap int_handler INT",
@@ -221,14 +228,15 @@ class TestIutMonitoring(TestCase):
         """
         self.logger.info("STEP: Initialize IUT monitoring.")
         iut_monitoring = IutMonitoring(None)
+        iut_monitoring.interrupt_timeout = 5
+        iut_monitoring.terminate_timeout = 5
+        iut_monitoring.kill_timeout = 5
 
         self.logger.info("STEP: Create and add multiple scripts with an infinite loop.")
         script = [
             "#!/bin/bash",
             "int_handler() {",
-            "   cat > $(pwd)/output << EOF",
-            "interrupted!",
-            "EOF",
+            "   echo interrupted! > $(pwd)/output",
             "   exit 0",
             "}",
             "trap int_handler INT",
@@ -246,9 +254,7 @@ class TestIutMonitoring(TestCase):
         script = [
             "#!/bin/bash",
             "int_handler() {",
-            "   cat > $(pwd)/output2 << EOF",
-            "interrupted!",
-            "EOF",
+            "   echo interrupted! > $(pwd)/output2",
             "   exit 0",
             "}",
             "trap int_handler INT",
@@ -305,6 +311,7 @@ class TestIutMonitoring(TestCase):
         iut_monitoring = IutMonitoring(None)
         iut_monitoring.interrupt_timeout = 5
         iut_monitoring.terminate_timeout = 5
+        iut_monitoring.kill_timeout = 5
 
         self.logger.info("STEP: Create and add a script catching SIGINT.")
         script = [
@@ -369,6 +376,7 @@ class TestIutMonitoring(TestCase):
         iut_monitoring = IutMonitoring(None)
         iut_monitoring.interrupt_timeout = 5
         iut_monitoring.terminate_timeout = 5
+        iut_monitoring.kill_timeout = 5
 
         self.logger.info("STEP: Create and add a script catching SIGINT and SIGTERM.")
         script = [


### PR DESCRIPTION


<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#24

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Added the 'commands' preparation step for IUT providers.
Changed so that IUT monitoring starts within the workspace.
Added execution of a script in IUT monitoring.
Added a global artifacts directory.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
This could be designed and added to ESR instead, however I think that adding it to ETR which had the support is less work and it already have the infrastructure ready to do it.
A longer discussion on whether this shall be added to ESR instead needs to be had.

### Benefits
<!-- What benefits will be realized by the change? -->
IUT Monitoring adds the ability to monitor the IUT during test execution and provide more information about the item under test.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
It's extra complexity, more things that can go wrong and a high learning curve for our users.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
