### PR TITLE
Send environment defined for EXECUTION_SPACE_URL if it exists

### DIFF
--- a/src/etos_test_runner/lib/iut_monitoring.py
+++ b/src/etos_test_runner/lib/iut_monitoring.py
@@ -74,6 +74,7 @@ class IutMonitoring:
             filestat = os.stat(script.get("name"))
             os.chmod(script.get("name"), filestat.st_mode | stat.S_IEXEC)
 
+            # These processes are closed elsewhere. pylint:disable=consider-using-with
             process = Popen(
                 [script.get("name"), *script.get("parameters", [])],
                 stdout=PIPE,

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -112,6 +112,12 @@ class TestRunner:
                 links={"CONTEXT": context},
                 host={"name": os.getenv("HOSTNAME"), "user": "etos"},
             )
+        if os.getenv("EXECUTION_SPACE_URL") is not None:
+            self.etos.events.send_environment_defined(
+                "Execution Space URL",
+                links={"CONTEXT": context},
+                host={"name": os.getenv("EXECUTION_SPACE_URL"), "user": "etos"},
+            )
 
     def run_tests(self, workspace):
         """Execute test recipes within a test executor.
@@ -183,7 +189,7 @@ class TestRunner:
             "conclusion": conclusion,
         }
 
-    def execute(self):  # pylint:disable=too-many-branches
+    def execute(self):  # pylint:disable=too-many-branches,disable=too-many-statements
         """Execute all tests in test suite.
 
         :return: Result of execution. Linux exit code.


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#84

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Read the environment variable EXECUTION_SPACE_URL and, if it exists, send an environment defined connected to the test suite.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
Could be sent as a part of the execution space setup instead, but since the test runner is executing in the execution space provider it should work just as well.

### Benefits
<!-- What benefits will be realized by the change? -->
Able to connect a URL to the ETOS execution when using external executors.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
The 'environment' method could grow and become very large in the future if we continue with this trend.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
