### PR TITLE
Add a longer timeout when waiting for publisher

### DIFF
--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -238,8 +238,9 @@ class TestRunner:
             if self.etos.feature_flags.clm:
                 self.logger.info("Send confidence event.")
                 self.confidence_level(result, test_suite_started)
-        timeout = time.time() + 30
-        self.logger.info("Waiting for eiffel publisher to deliver events (30s).")
+
+        timeout = time.time() + 600  # 10 minutes
+        self.logger.info("Waiting for eiffel publisher to deliver events (600s).")
 
         previous = 0
         # pylint:disable=protected-access


### PR DESCRIPTION

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
This is an attempt to alleviate problems with a large test suite finished event that is generated during the tests.
We have seen problems with the test suite finished not being sent after ETR is done. Working theory is that the event is too large and RabbitMQ drops the message silently.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I thought about setting it as a variable that can be overriden, but I don't want to encourage its use.
We should also, in the future, attach logs to test case events instead of test suite events. This is a large change however and I want to wait with that.

### Benefits
<!-- What benefits will be realized by the change? -->
Hopefully allows us to send events reliably at the end of ETR.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
If this change does not work, then we are hogging resources for 570s longer than before

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
