### PR TITLE
Make sure we actually close the regex file

### DIFF
--- a/src/etos_test_runner/lib/executor.py
+++ b/src/etos_test_runner/lib/executor.py
@@ -95,7 +95,8 @@ class Executor:  # pylint:disable=too-many-instance-attributes
             try:
                 path = Path(os.getenv("TEST_REGEX"))
                 if path.exists() and path.is_file():
-                    regex = json.load(path.open(encoding="utf-8"))
+                    with path.open(encoding="utf-8") as regex_file:
+                        regex = json.load(regex_file)
                     for key, value in regex.items():
                         self.test_regex[key] = re.compile(value)
                 else:


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
We don't close the regex file after loading it.

```
/home/etos/.pyenv/versions/3.9.0/lib/python3.9/site-packages/etos_test_runner/lib/executor.py:98: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/etos/my_regex.json' mode='r' encoding='utf-8'>
  regex = json.load(path.open(encoding="utf-8"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```
### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
None was considered.

### Benefits
<!-- What benefits will be realized by the change? -->
No fds are held unnecessarily

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
