### PR TITLE
Ignore test name errors instead of crashing

### DIFF
--- a/src/etos_test_runner/lib/log_area.py
+++ b/src/etos_test_runner/lib/log_area.py
@@ -105,7 +105,7 @@ class LogArea:
         :return: Filenames and paths.
         :rtype: list
         """
-        test_name = self.etos.config.get("current_test")
+        test_name = self.etos.config.get("test_name")
         items = []
         self.logger.info("Collecting logs/artifacts for %r", test_name or "global")
         for item in path.iterdir():
@@ -148,7 +148,7 @@ class LogArea:
         :param artifacts: Artifacts that exists within this event.
         :type artifacts: list
         """
-        test_name = self.etos.config.get("current_test")
+        test_name = self.etos.config.get("test_name")
         if test_name:
             identity = f"pkg:etos-test-output/{self.suite_name}/{test_name}"
         else:

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -154,7 +154,7 @@ class TestRunner:
             description = f"At least some {suite_name} tests failed."
         elif not description and result:
             self.logger.info(
-                "No description and result is a success. " "All tests executed successfully."
+                "No description and result is a success. All tests executed successfully."
             )
             description = f"All {suite_name} tests completed successfully."
         else:
@@ -182,6 +182,7 @@ class TestRunner:
 
         result = True
         description = None
+        executed = False
         try:
             with Workspace(self.log_area) as workspace:
                 self.logger.info("Start IUT monitoring.")

--- a/tests/scenarios/test_log_upload.py
+++ b/tests/scenarios/test_log_upload.py
@@ -236,6 +236,7 @@ class TestLogUpload(TestCase):
                 )
                 self.assertTrue(as_json)
 
+                # pylint:disable=modified-iterating-list
                 for path in filenames:
                     if filename.name == path:
                         filenames.remove(path)

--- a/tests/scenarios/test_no_detected_test_name.py
+++ b/tests/scenarios/test_no_detected_test_name.py
@@ -26,7 +26,7 @@ from etos_lib.lib.debug import Debug
 from etos_test_runner.etr import ETR
 
 TEST = """#!/bin/bash
-echo ==== test_name_yo ====
+echo === cannot_be_found ===
 echo == STARTED ==
 echo == PASSED ==
 exit 0
@@ -35,7 +35,7 @@ exit 0
 REGEX = """{
     "test_name": "==== (.*) ====",
     "triggered": "==== .* ====",
-    "started": "== STARTED ==",
+    "started": "==== .* ====",
     "passed": "== PASSED ==",
     "failed": "== FAILED ==",
     "skipped": "== SKIPPED ==",
@@ -44,7 +44,7 @@ REGEX = """{
 """
 
 SUITE = {
-    "name": "Test ETOS API scenario",
+    "name": "Test ETOS API scenario undetected test name",
     "priority": 1,
     "recipes": [
         {
@@ -180,42 +180,16 @@ class TestFullExecution(TestCase):
             else:
                 os.environ[key] = value
 
-    def validate_event_name_order(self, events):
-        """Validate ETR sent events.
-
-        :raises AssertionError: If events are not correct.
-
-        :param events: All events sent, in order.
-        :type events: deque
-        """
-        self.logger.info(events)
-        event_names_in_order = [
-            "EiffelActivityTriggeredEvent",
-            "EiffelActivityStartedEvent",
-            "EiffelTestSuiteStartedEvent",
-            "EiffelTestCaseTriggeredEvent",
-            "EiffelTestCaseStartedEvent",
-            "EiffelTestCaseFinishedEvent",
-            "EiffelArtifactCreatedEvent",
-            "EiffelArtifactPublishedEvent",
-            "EiffelTestSuiteFinishedEvent",
-            "EiffelActivityFinishedEvent",
-        ]
-        for event_name in event_names_in_order:
-            self.assertEqual(events.popleft().meta.type, event_name)
-        self.assertEqual(list(events), [])
-
-    def test_full(self):
-        """Test that a full execution scenario works as expected.
+    def test_not_finding_test_name(self):
+        """Test that execution finished properly even if no test name is detected.
 
         Approval criteria:
-            - It shall be possible to execute a full suite in ETR.
-            - ETR shall send events in the correct order.
+            - It shall be possible to execute a full suite in ETR even if
+              a test name is not detected.
 
         Test steps::
             1. Initialize and run ETR.
-            2. Verify that events were sent in the correct order.
-            3. Verify that ETR returned with status code 0.
+            2. Verify that ETR returned with status code 0.
         """
 
         environment = {
@@ -230,9 +204,6 @@ class TestFullExecution(TestCase):
             self.logger.info("STEP: Initialize and run ETR.")
             etr = ETR()
             result = etr.run_etr()
-
-            self.logger.info("STEP: Verify that events were sent in the correct order.")
-            self.validate_event_name_order(self.debug.events_published.copy())
 
             self.logger.info("STEP: Verify that ETR returned with status code 0.")
             # Result is either dictionary with outcome or an exit status code.


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#123

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Made sure to not fail when we cannot detect a test case. I also changed a few variable names as to not be confusing and cleaned up some black and pylint errors.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We could fail in another way in order to inform the users that something failed with detecting test case name, but I think this should be done in other parts of ETOS instead.

### Benefits
<!-- What benefits will be realized by the change? -->
The test runner won't have any real opinions in how the user run their tests.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
False positives are a problem, but should be fixed in other parts of ETOS.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
