### PR TITLE
Add proper logging from ETOS Test Runner.

### DIFF
--- a/src/etos_test_runner/__init__.py
+++ b/src/etos_test_runner/__init__.py
@@ -14,14 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS test runner module."""
-from pkg_resources import get_distribution, DistributionNotFound
+import os
+from importlib.metadata import version, PackageNotFoundError
+from etos_lib.logging.logger import setup_logging
 
-# pylint:disable=invalid-name
 try:
-    # Change here if project is renamed and does not equal the package name
-    dist_name = __name__
-    __version__ = get_distribution(dist_name).version
-except DistributionNotFound:
-    __version__ = "unknown"
-finally:
-    del get_distribution, DistributionNotFound
+    VERSION = version("etos_test_runner")
+except PackageNotFoundError:
+    VERSION = "Unknown"
+
+DEV = os.getenv("DEV", "false").lower() == "true"
+ENVIRONMENT = "development" if DEV else "production"
+setup_logging("ETOS Test Runner", VERSION, ENVIRONMENT)

--- a/src/etos_test_runner/etr.py
+++ b/src/etos_test_runner/etr.py
@@ -112,9 +112,7 @@ class ETR:
         for name, module in discovered_plugins.items():
             _LOGGER.info("Loading plugin: %r", name)
             if not hasattr(module, "ETRPlugin"):
-                raise AttributeError(
-                    f"{name} does not have an ETRPlugin class!"
-                )
+                raise AttributeError(f"{name} does not have an ETRPlugin class!")
             plugins.append(module.ETRPlugin(self.etos))
         self.etos.config.set("plugins", plugins)
 

--- a/src/etos_test_runner/etr.py
+++ b/src/etos_test_runner/etr.py
@@ -133,7 +133,7 @@ class ETR:
             triggered = self.etos.events.send_activity_triggered(activity_name)
             self.etos.events.send_activity_started(triggered)
             result = self._run_tests()
-        except Exception as exc:  # pylint:disable=broad-exception-raised
+        except Exception as exc:  # pylint:disable=broad-except
             self.etos.events.send_activity_finished(
                 triggered, {"conclusion": "FAILED", "description": str(exc)}
             )

--- a/src/etos_test_runner/etr.py
+++ b/src/etos_test_runner/etr.py
@@ -26,8 +26,9 @@ import pkgutil
 from pprint import pprint
 
 from etos_lib import ETOS
+from etos_lib.logging.logger import FORMAT_CONFIG
 
-from etos_test_runner import __version__
+from etos_test_runner import VERSION
 from etos_test_runner.lib.testrunner import TestRunner
 from etos_test_runner.lib.iut import Iut
 
@@ -36,13 +37,6 @@ from etos_test_runner.lib.iut import Iut
 logging.getLogger("pika").setLevel(logging.WARNING)
 
 _LOGGER = logging.getLogger(__name__)
-LOGFORMAT = "[%(asctime)s] %(levelname)s:%(message)s"
-logging.basicConfig(
-    level=logging.DEBUG,
-    stream=sys.stdout,
-    format=LOGFORMAT,
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
 
 
 def parse_args(args):
@@ -56,7 +50,7 @@ def parse_args(args):
         "-v",
         "--version",
         action="version",
-        version=f"etos_test_runner {__version__}",
+        version=f"etos_test_runner {VERSION}",
     )
     return parser.parse_args(args)
 
@@ -69,6 +63,7 @@ class ETR:
     def __init__(self):
         """Initialize ETOS library and start eiffel publisher."""
         self.etos = ETOS("ETOS Test Runner", os.getenv("HOSTNAME"), "ETOS Test Runner")
+
         self.etos.config.rabbitmq_publisher_from_environment()
         # ETR will print the entire environment just before executing.
         # Hide the password.
@@ -82,7 +77,7 @@ class ETR:
     @staticmethod
     def graceful_shutdown(*args):
         """Catch sigterm."""
-        raise Exception("ETR has been terminated.")
+        raise Exception("ETR has been terminated.")  # pylint:disable=broad-exception-raised
 
     def download_and_load(self):
         """Download and load test json."""
@@ -94,6 +89,7 @@ class ETR:
         self.etos.config.set("context", json_config.get("context"))
         self.etos.config.set("artifact", json_config.get("artifact"))
         self.etos.config.set("main_suite_id", json_config.get("test_suite_started_id"))
+        self.etos.config.set("suite_id", json_config.get("suite_id"))
 
     def _run_tests(self):
         """Run tests in ETOS test runner.
@@ -116,7 +112,9 @@ class ETR:
         for name, module in discovered_plugins.items():
             _LOGGER.info("Loading plugin: %r", name)
             if not hasattr(module, "ETRPlugin"):
-                raise Exception(f"{name} does not have an ETRPlugin class!")
+                raise Exception(  # pylint:disable=broad-exception-raised
+                    f"{name} does not have an ETRPlugin class!"
+                )
             plugins.append(module.ETRPlugin(self.etos))
         self.etos.config.set("plugins", plugins)
 
@@ -128,13 +126,14 @@ class ETR:
         """
         _LOGGER.info("Starting ETR.")
         self.download_and_load()
+        FORMAT_CONFIG.identifier = self.etos.config.get("suite_id")
         self.load_plugins()
         try:
             activity_name = self.etos.config.get("test_config").get("name")
             triggered = self.etos.events.send_activity_triggered(activity_name)
             self.etos.events.send_activity_started(triggered)
             result = self._run_tests()
-        except Exception as exc:  # pylint:disable=broad-except
+        except Exception as exc:  # pylint:disable=broad-exception-raised
             self.etos.events.send_activity_finished(
                 triggered, {"conclusion": "FAILED", "description": str(exc)}
             )

--- a/src/etos_test_runner/etr.py
+++ b/src/etos_test_runner/etr.py
@@ -112,7 +112,7 @@ class ETR:
         for name, module in discovered_plugins.items():
             _LOGGER.info("Loading plugin: %r", name)
             if not hasattr(module, "ETRPlugin"):
-                raise Exception(  # pylint:disable=broad-exception-raised
+                raise AttributeError(
                     f"{name} does not have an ETRPlugin class!"
                 )
             plugins.append(module.ETRPlugin(self.etos))

--- a/src/etos_test_runner/lib/executor.py
+++ b/src/etos_test_runner/lib/executor.py
@@ -153,7 +153,7 @@ class Executor:  # pylint:disable=too-many-instance-attributes
             signal.alarm(0)
         if not success:
             pprint(output)
-            raise Exception(  # pylint:disable=broad-exception-raised
+            raise RuntimeError(
                 f"Could not checkout tests using {test_checkout!r}"
             )
 

--- a/src/etos_test_runner/lib/executor.py
+++ b/src/etos_test_runner/lib/executor.py
@@ -20,6 +20,7 @@ import logging
 import signal
 import json
 import re
+import subprocess
 from pathlib import Path
 from shutil import copy
 from pprint import pprint
@@ -27,8 +28,17 @@ from pprint import pprint
 BASE = Path(__file__).parent.absolute()
 
 
+class SubprocessReadTimeout(Exception):
+    """Timeout on reading from subprocess."""
+
+
 class TestCheckoutTimeout(TimeoutError):
     """Test checkout timeout exception."""
+
+
+def _subprocess_signal_handler(signum, frame):  # pylint:disable=unused-argument
+    """Raise subprocess read timeout."""
+    raise SubprocessReadTimeout("Timeout while reading subprocess stdout.")
 
 
 def _test_checkout_signal_handler(signum, frame):  # pylint:disable=unused-argument
@@ -111,7 +121,7 @@ class Executor:  # pylint:disable=too-many-instance-attributes
             except json.decoder.JSONDecodeError as exception:
                 self.logger.error("%r", exception)
                 self.logger.error("Failed to load JSON %r", path)
-            except Exception as exception:  # pylint:disable=broad-except
+            except Exception as exception:  # pylint:disable=broad-exception-caught
                 self.logger.error("%r", exception)
                 self.logger.error("Unknown error when loading regex JSON file.")
 
@@ -136,14 +146,16 @@ class Executor:  # pylint:disable=too-many-instance-attributes
         signal.signal(signal.SIGALRM, _test_checkout_signal_handler)
         signal.alarm(60)
         try:
-            success, output = self.etos.utils.call(
+            success, output = self._call(
                 ["/bin/bash", str(checkout)], shell=True, wait_output=False
             )
         finally:
             signal.alarm(0)
         if not success:
             pprint(output)
-            raise Exception(f"Could not checkout tests using {test_checkout!r}")
+            raise Exception(  # pylint:disable=broad-exception-raised
+                f"Could not checkout tests using {test_checkout!r}"
+            )
 
     def _build_test_command(self):
         """Build up the actual test command based on data from event."""
@@ -232,6 +244,106 @@ class Executor:  # pylint:disable=too-many-instance-attributes
             plugin.on_test_case_finished(test_name, result)
         self.current_test = None
 
+    def _call(
+        self, cmd, shell=False, env=None, executable=None, output=None, wait_output=True
+    ):  # pylint:disable=too-many-arguments
+        """Call a system command.
+
+        :param cmd: Command to run.
+        :type cmd: list
+        :param env: Override subprocess environment.
+        :type env: dict
+        :param executable: Override subprocess executable.
+        :type executable: str
+        :param output: Path to a file to write stdout to.
+        :type output: str
+        :param wait_output: Whether or not to wait for output.
+                            Some commands can fail in a non-interactive
+                            shell due to waiting for 'readline' forever.
+                            Set this to False on commands that we're
+                            not in control of.
+        :type wait_output: boolean
+        :return: Result and output from command.
+        :rtype: tuple
+        """
+        out = []
+        for _, line in self._iterable_call(cmd, shell, env, executable, output, wait_output):
+            if isinstance(line, str):
+                out.append(line)
+            else:
+                success = line
+                break
+        return success, out
+
+    def _iterable_call(
+        self, cmd, shell=False, env=None, executable=None, output=None, wait_output=True
+    ):  # pylint:disable=too-many-arguments
+        """Call a system command and yield the output.
+
+        :param cmd: Command to run.
+        :type cmd: list
+        :param env: Override subprocess environment.
+        :type env: dict
+        :param executable: Override subprocess executable.
+        :type executable: str
+        :param output: Path to a file to write stdout to.
+        :type output: str
+        :param wait_output: Whether or not to wait for output.
+                            Some commands can fail in a non-interactive
+                            shell due to waiting for 'readline' forever.
+                            Set this to False on commands that we're
+                            not in control of.
+        :type wait_output: boolean
+        :return: Result and output from command.
+        :rtype: tuple
+        """
+        self.logger.debug("Running command: %s", " ".join(cmd))
+        if shell:
+            cmd = " ".join(cmd)
+        proc = subprocess.Popen(  # pylint:disable=consider-using-with
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            shell=shell,
+            env=env,
+            executable=executable,
+        )
+
+        signal.signal(signal.SIGALRM, _subprocess_signal_handler)
+        output_file = None
+        try:
+            if output:
+                # pylint:disable=consider-using-with
+                output_file = open(output, "w", encoding="utf-8")
+            # Make sure you can read all output with 'docker logs'
+            for line in iter(proc.stdout.readline, b""):
+                yield proc, line.decode("utf-8")
+                self.logger.info(line.decode("utf-8").strip())
+                signal.alarm(0)
+
+                if output_file:
+                    output_file.write(line.decode("utf-8"))
+
+                if not wait_output:
+                    signal.alarm(5)
+        except SubprocessReadTimeout:
+            pass
+        finally:
+            if output_file:
+                output_file.close()
+
+        _, err = proc.communicate()
+        if err is not None:
+            self.logger.debug(err.decode("utf-8"))
+        self.logger.debug("Return code: %s (0=Good >0=Bad)", proc.returncode)
+
+        # Unix return code 0 = success >0 = failure.
+        # Python int 0 = failure >0 = success.
+        # Converting unix return code to python bool.
+        success = not proc.returncode
+
+        yield proc, success
+
     def parse(self, line):
         """Parse test output in order to send test case events.
 
@@ -284,7 +396,7 @@ class Executor:  # pylint:disable=too-many-instance-attributes
             command = self._build_test_command()
 
             self.logger.info("Run test command: %r", command)
-            iterator = self.etos.utils.iterable_call(
+            iterator = self._iterable_call(
                 [command], shell=True, executable="/bin/bash", output=self.report_path
             )
 

--- a/src/etos_test_runner/lib/executor.py
+++ b/src/etos_test_runner/lib/executor.py
@@ -153,9 +153,7 @@ class Executor:  # pylint:disable=too-many-instance-attributes
             signal.alarm(0)
         if not success:
             pprint(output)
-            raise RuntimeError(
-                f"Could not checkout tests using {test_checkout!r}"
-            )
+            raise RuntimeError(f"Could not checkout tests using {test_checkout!r}")
 
     def _build_test_command(self):
         """Build up the actual test command based on data from event."""

--- a/src/etos_test_runner/lib/iut_monitoring.py
+++ b/src/etos_test_runner/lib/iut_monitoring.py
@@ -22,12 +22,13 @@ from threading import Thread
 from signal import SIGINT
 from subprocess import Popen, PIPE, STDOUT, TimeoutExpired
 from etos_lib.lib.config import Config
+from etos_lib.logging.logger import FORMAT_CONFIG
 
 
 ON_POSIX = "posix" in sys.builtin_module_names
 
 
-class IutMonitoring:
+class IutMonitoring:  # pylint:disable=too-many-instance-attributes
     """Helper class for monitoring IuT health statistics."""
 
     logger = logging.getLogger("IUT Monitoring")
@@ -36,12 +37,13 @@ class IutMonitoring:
     kill_timeout = 30  # Seconds
     monitoring = False
 
-    def __init__(self, iut):
+    def __init__(self, iut, etos):
         """Initialize monitoring.
 
         :param iut: IUT object to monitor.
         :type iut: :obj:`etr.lib.iut.Iut`
         """
+        self.etos = etos
         self.iut = iut
         self.processes = []
         self.config = Config()
@@ -52,9 +54,10 @@ class IutMonitoring:
         :param output: Output to read from.
         :type output: filedescriptor
         """
+        FORMAT_CONFIG.identifier = self.etos.config.get("suite_id")
         self.logger.info("Reading output from %r", output)
         for line in iter(output.readline, b""):
-            self.logger.info(line.decode("utf-8"))
+            self.logger.info(line.decode("utf-8").strip())
         output.close()
 
     def start_monitoring(self):

--- a/src/etos_test_runner/lib/iut_monitoring.py
+++ b/src/etos_test_runner/lib/iut_monitoring.py
@@ -42,6 +42,8 @@ class IutMonitoring:  # pylint:disable=too-many-instance-attributes
 
         :param iut: IUT object to monitor.
         :type iut: :obj:`etr.lib.iut.Iut`
+        :param etos: ETOS library instance.
+        :type etos: :obj:`etos_lib.etos.Etos`
         """
         self.etos = etos
         self.iut = iut

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -214,7 +214,7 @@ class TestRunner:
                 executed = True
                 self.logger.info("Stop IUT monitoring.")
                 self.iut_monitoring.stop_monitoring()
-        except Exception as exception:  # pylint:disable=broad-exception-raised
+        except Exception as exception:  # pylint:disable=broad-except
             result = False
             executed = False
             description = str(exception)

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -43,7 +43,7 @@ class TestRunner:
         self.config = self.etos.config.get("test_config")
 
         self.log_area = LogArea(self.etos)
-        self.iut_monitoring = IutMonitoring(self.iut)
+        self.iut_monitoring = IutMonitoring(self.iut, self.etos)
         self.issuer = {"name": "ETOS Test Runner"}
         self.etos.config.set("iut", self.iut)
         self.plugins = self.etos.config.get("plugins")
@@ -214,7 +214,7 @@ class TestRunner:
                 executed = True
                 self.logger.info("Stop IUT monitoring.")
                 self.iut_monitoring.stop_monitoring()
-        except Exception as exception:  # pylint:disable=broad-except
+        except Exception as exception:  # pylint:disable=broad-exception-raised
             result = False
             executed = False
             description = str(exception)
@@ -254,7 +254,9 @@ class TestRunner:
                     )
                     timeout = time.time() + 10
                 else:
-                    raise Exception("Eiffel publisher did not deliver all eiffel events.")
+                    raise Exception(  # pylint:disable=broad-exception-raised
+                        "Eiffel publisher did not deliver all eiffel events."
+                    )
             previous = current
             time.sleep(1)
         self.logger.info("Tests finished executing.")

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -254,9 +254,7 @@ class TestRunner:
                     )
                     timeout = time.time() + 10
                 else:
-                    raise TimeoutError(
-                        "Eiffel publisher did not deliver all eiffel events."
-                    )
+                    raise TimeoutError("Eiffel publisher did not deliver all eiffel events.")
             previous = current
             time.sleep(1)
         self.logger.info("Tests finished executing.")

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -254,7 +254,7 @@ class TestRunner:
                     )
                     timeout = time.time() + 10
                 else:
-                    raise Exception(  # pylint:disable=broad-exception-raised
+                    raise TimeoutError(
                         "Eiffel publisher did not deliver all eiffel events."
                     )
             previous = current

--- a/src/etos_test_runner/lib/workspace.py
+++ b/src/etos_test_runner/lib/workspace.py
@@ -167,7 +167,7 @@ class Workspace:
     def compress(self):
         """Compress the entire workspace folder."""
         if self.workspace is None or not self.workspace.is_dir():
-            raise Exception("Workspace not created.")  # pylint:disable=broad-exception-raised
+            raise FileNotFoundError("Workspace not created.")
         self.logger.info("Compress workspace directory")
         compressed_workspace = self.top_dir.joinpath("workspace").relative_to(Path.cwd())
         filename = make_archive(

--- a/src/etos_test_runner/lib/workspace.py
+++ b/src/etos_test_runner/lib/workspace.py
@@ -131,7 +131,7 @@ class Workspace:
         :rtype: :obj:`pathlib.Path`
         """
         if self.workspace is None or not self.workspace.is_dir():
-            raise Exception("Workspace not created.")
+            raise Exception("Workspace not created.")  # pylint:disable=broad-exception-raised
         try:
             self.logger.info("Getting test directory with identifier %r", identifier)
             if self.identifiers.get(identifier) is None:
@@ -167,7 +167,7 @@ class Workspace:
     def compress(self):
         """Compress the entire workspace folder."""
         if self.workspace is None or not self.workspace.is_dir():
-            raise Exception("Workspace not created.")
+            raise Exception("Workspace not created.")  # pylint:disable=broad-exception-raised
         self.logger.info("Compress workspace directory")
         compressed_workspace = self.top_dir.joinpath("workspace").relative_to(Path.cwd())
         filename = make_archive(

--- a/src/etos_test_runner/lib/workspace.py
+++ b/src/etos_test_runner/lib/workspace.py
@@ -131,7 +131,7 @@ class Workspace:
         :rtype: :obj:`pathlib.Path`
         """
         if self.workspace is None or not self.workspace.is_dir():
-            raise Exception("Workspace not created.")  # pylint:disable=broad-exception-raised
+            raise FileNotFoundError("Workspace not created.")
         try:
             self.logger.info("Getting test directory with identifier %r", identifier)
             if self.identifiers.get(identifier) is None:

--- a/tests/lib/test_iut_monitoring.py
+++ b/tests/lib/test_iut_monitoring.py
@@ -20,7 +20,7 @@ import logging
 import time
 from pathlib import Path
 from unittest import TestCase
-from etos_lib.lib.config import Config
+from etos_lib import ETOS
 from etos_test_runner.lib.iut_monitoring import IutMonitoring
 
 logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
@@ -38,7 +38,8 @@ class TestIutMonitoring(TestCase):
         with open(self.script, "w", encoding="utf-8") as scriptfile:
             for line in script:
                 scriptfile.write(f"{line}\n")
-        self.config = Config()
+        self.etos = ETOS("ETR Test", "ETR Test Host", "ETR Test")
+        self.config = self.etos.config
         self.files = [self.script, Path.cwd().joinpath("output")]
 
     def tearDown(self):
@@ -86,7 +87,7 @@ class TestIutMonitoring(TestCase):
             4. Verify that the script executed.
         """
         self.logger.info("STEP: Initialize IUT monitoring.")
-        iut_monitoring = IutMonitoring(None)
+        iut_monitoring = IutMonitoring(None, self.etos)
         iut_monitoring.interrupt_timeout = 5
         iut_monitoring.terminate_timeout = 5
         iut_monitoring.kill_timeout = 5
@@ -117,7 +118,7 @@ class TestIutMonitoring(TestCase):
             4. Verify that the scripts executed.
         """
         self.logger.info("STEP: Initialize IUT monitoring.")
-        iut_monitoring = IutMonitoring(None)
+        iut_monitoring = IutMonitoring(None, self.etos)
         iut_monitoring.interrupt_timeout = 5
         iut_monitoring.terminate_timeout = 5
         iut_monitoring.kill_timeout = 5
@@ -167,7 +168,7 @@ class TestIutMonitoring(TestCase):
             5. Verify that the script was interrupted with SIGINT.
         """
         self.logger.info("STEP: Initialize IUT monitoring.")
-        iut_monitoring = IutMonitoring(None)
+        iut_monitoring = IutMonitoring(None, self.etos)
         iut_monitoring.interrupt_timeout = 5
         iut_monitoring.terminate_timeout = 5
         iut_monitoring.kill_timeout = 5
@@ -225,7 +226,7 @@ class TestIutMonitoring(TestCase):
             5. Verify that the scripts were interrupted with SIGINT.
         """
         self.logger.info("STEP: Initialize IUT monitoring.")
-        iut_monitoring = IutMonitoring(None)
+        iut_monitoring = IutMonitoring(None, self.etos)
         iut_monitoring.interrupt_timeout = 5
         iut_monitoring.terminate_timeout = 5
         iut_monitoring.kill_timeout = 5
@@ -306,7 +307,7 @@ class TestIutMonitoring(TestCase):
             5. Verify that the script was interrupted with SIGTERM.
         """
         self.logger.info("STEP: Initialize IUT monitoring.")
-        iut_monitoring = IutMonitoring(None)
+        iut_monitoring = IutMonitoring(None, self.etos)
         iut_monitoring.interrupt_timeout = 5
         iut_monitoring.terminate_timeout = 5
         iut_monitoring.kill_timeout = 5
@@ -371,7 +372,7 @@ class TestIutMonitoring(TestCase):
             5. Verify that the script was killed.
         """
         self.logger.info("STEP: Initialize IUT monitoring.")
-        iut_monitoring = IutMonitoring(None)
+        iut_monitoring = IutMonitoring(None, self.etos)
         iut_monitoring.interrupt_timeout = 5
         iut_monitoring.terminate_timeout = 5
         iut_monitoring.kill_timeout = 5

--- a/tests/lib/test_workspace.py
+++ b/tests/lib/test_workspace.py
@@ -193,7 +193,7 @@ class TestWorkspace(TestCase):
                     "STEP: Check that test directory was created and exit the context."
                 )
                 if not directory.exists() and directory.is_dir():
-                    raise Exception(  # pylint:disable=broad-exception-raised
+                    raise FileNotFoundError(
                         "Test directory was not properly created."
                     )
                 first_stat = directory.stat()

--- a/tests/lib/test_workspace.py
+++ b/tests/lib/test_workspace.py
@@ -203,7 +203,7 @@ class TestWorkspace(TestCase):
                     "STEP: Enter a test directory in a context manager with the same identifer."
                 )
                 if not directory.exists() and directory.is_dir():
-                    raise Exception(  # pylint:disable=broad-exception-raised
+                    raise FileNotFoundError(
                         "Test directory was not properly created."
                     )
 

--- a/tests/lib/test_workspace.py
+++ b/tests/lib/test_workspace.py
@@ -193,9 +193,7 @@ class TestWorkspace(TestCase):
                     "STEP: Check that test directory was created and exit the context."
                 )
                 if not directory.exists() and directory.is_dir():
-                    raise FileNotFoundError(
-                        "Test directory was not properly created."
-                    )
+                    raise FileNotFoundError("Test directory was not properly created.")
                 first_stat = directory.stat()
 
             with workspace.test_directory("dir1") as directory:
@@ -203,9 +201,7 @@ class TestWorkspace(TestCase):
                     "STEP: Enter a test directory in a context manager with the same identifer."
                 )
                 if not directory.exists() and directory.is_dir():
-                    raise FileNotFoundError(
-                        "Test directory was not properly created."
-                    )
+                    raise FileNotFoundError("Test directory was not properly created.")
 
                 self.logger.info("STEP: Verify that the folder was re-used.")
                 self.assertEqual(

--- a/tests/lib/test_workspace.py
+++ b/tests/lib/test_workspace.py
@@ -193,7 +193,9 @@ class TestWorkspace(TestCase):
                     "STEP: Check that test directory was created and exit the context."
                 )
                 if not directory.exists() and directory.is_dir():
-                    raise Exception("Test directory was not properly created.")
+                    raise Exception(  # pylint:disable=broad-exception-raised
+                        "Test directory was not properly created."
+                    )
                 first_stat = directory.stat()
 
             with workspace.test_directory("dir1") as directory:
@@ -201,7 +203,9 @@ class TestWorkspace(TestCase):
                     "STEP: Enter a test directory in a context manager with the same identifer."
                 )
                 if not directory.exists() and directory.is_dir():
-                    raise Exception("Test directory was not properly created.")
+                    raise Exception(  # pylint:disable=broad-exception-raised
+                        "Test directory was not properly created."
+                    )
 
                 self.logger.info("STEP: Verify that the folder was re-used.")
                 self.assertEqual(


### PR DESCRIPTION


### Applicable Issues
None

### Description of the Change
To increase observability of the ETOS Test Runner all relevant output is now done via python logging library, with support for suite ID (TERCC_ID) as a correlation identifier.

### Alternate Designs
None

### Benefits
Increased observability. We now get more regardign outputs from ETOS Test Runner as well as the possibility to send logs to remote log servers for further processing.

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
