### PR TITLE
Call plugins test_suite_started after test suite has started

### DIFF
--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -166,14 +166,14 @@ class TestRunner:
         for plugin in self.plugins:
             plugin.on_test_suite_triggered(name)
 
-    def _test_suite_started(self, name):
+    def _test_suite_started(self, test_suite_started):
         """Call on_test_suite_started for all ETR plugins.
 
-        :param name: Name of test suite that finished.
-        :type name: str
+        :param test_suite_started: The test suite started event
+        :type test_suite_started: :obj:`eiffellib.events.EiffelTestSuiteStartedEvent`
         """
         for plugin in self.plugins:
-            plugin.on_test_suite_started(name)
+            plugin.on_test_suite_started(test_suite_started)
 
     def _test_suite_finished(self, name, outcome):
         """Call on_test_suite_finished for all ETR plugins.
@@ -194,8 +194,8 @@ class TestRunner:
         """
         self._test_suite_triggered(self.config.get("name"))
         self.logger.info("Send test suite started event.")
-        self._test_suite_started(self.config.get("name"))
         test_suite_started = self.test_suite_started()
+        self._test_suite_started(test_suite_started)
         sub_suite_id = test_suite_started.meta.event_id
 
         self.logger.info("Send test environment events.")

--- a/src/etos_test_runner/plugins/plugin.py
+++ b/src/etos_test_runner/plugins/plugin.py
@@ -33,11 +33,11 @@ class ETRPlugin:
         :type test_suite_name: str
         """
 
-    def on_test_suite_started(self, test_suite_name):
+    def on_test_suite_started(self, test_suite_started):
         """Call when a test suite has started.
 
-        :param test_suite_name: Name of test suite that has started.
-        :type test_suite_name: str
+        :param test_suite_started: The test suite started event.
+        :type test_suite_started: :obj:`eiffellib.events.EiffelTestSuiteStartedEvent`
         """
 
     def on_test_suite_finished(self, test_suite_name, outcome):


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
So that plugins can react to a started test suite, call them when the test suite has actually started.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
None.

### Benefits
<!-- What benefits will be realized by the change? -->
The test suite started event ID can now be used in plugins

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
We are changing the plugin API with this change, but it's such a niche and unused feature that I don't see a problem with it.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
