### PR TITLE
Environment variable moved to before setting up logging

### DIFF
--- a/src/etos_test_runner/__init__.py
+++ b/src/etos_test_runner/__init__.py
@@ -24,6 +24,9 @@ try:
 except PackageNotFoundError:
     VERSION = "Unknown"
 
+# Disable sending logs for now.
+os.environ["ETOS_ENABLE_SENDING_LOGS"] = "false"
+
 DEV = os.getenv("DEV", "false").lower() == "true"
 ENVIRONMENT = "development" if DEV else "production"
 setup_logging("ETOS Test Runner", VERSION, ENVIRONMENT)

--- a/src/etos_test_runner/etr.py
+++ b/src/etos_test_runner/etr.py
@@ -178,8 +178,6 @@ def main(args):
 
 def run():
     """Entry point to ETR."""
-    # Disable sending logs for now.
-    os.environ["ETOS_ENABLE_SENDING_LOGS"] = "false"
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)
     main(sys.argv[1:])
 


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
None

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Moved environment variable so that the ETR can start. The `setup_logging` was run before setting the environment variable stopping internal logs in ETOS, it needs to run after that variable has been set.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
