### PR TITLE
Dependabot fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@
 # scipy==1.0
 #
 packageurl-python==0.9.1
-cryptography~=41.0
+cryptography>=42.0.4,<43.0.0
 etos_lib==3.2.2
 jsontas==1.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ package_dir =
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 install_requires =
     etos_lib==3.2.2
-    cryptography~=41.0
+    cryptography>=42.0.4,<43.0.0
     packageurl-python==0.9.1
     jsontas==1.3.0
 


### PR DESCRIPTION
A few security problems were detected by dependabot with the cryptography package.
Manually updating versions as depenedabot does not work in this repository.
