### PR TITLE
Make sub suite and main suite IDs available on upload

### DIFF
--- a/src/etos_test_runner/lib/log_area.py
+++ b/src/etos_test_runner/lib/log_area.py
@@ -129,15 +129,13 @@ class LogArea:
         :param logs: Logs to upload.
         :type logs: list
         """
-        log_area_folder = (
-            f"{self.etos.config.get('main_suite_id')}/{self.etos.config.get('sub_suite_id')}"
-        )
         for log in logs:
             log["uri"] = self.__upload(
                 self.etos.config.get("context"),
                 log["file"],
                 log["name"],
-                log_area_folder,
+                self.etos.config.get("main_suite_id"),
+                self.etos.config.get("sub_suite_id"),
             )
             self.logs.append(log)
             log["file"].unlink()
@@ -202,7 +200,8 @@ class LogArea:
                 self.etos.config.get("context"),
                 artifact["file"],
                 artifact["name"],
-                log_area_folder,
+                self.etos.config.get("main_suite_id"),
+                self.etos.config.get("sub_suite_id"),
             )
             self.artifacts.append(artifact)
             artifact["file"].unlink()
@@ -211,12 +210,14 @@ class LogArea:
         data = {
             "context": self.etos.config.get("context"),
             "folder": log_area_folder,
+            "sub_suite_id": self.etos.config.get("sub_suite_id"),
+            "main_suite_id": self.etos.config.get("main_suite_id"),
             "name": "",
         }
         published_url = upload["url"].format(**data)
         self._artifact_published(artifact_created, published_url)
 
-    def __upload(self, context, log, name, folder):
+    def __upload(self, context, log, name, main_suite_id, sub_suite_id):
         """Upload log to a storage location.
 
         :param context: Context for the http request.
@@ -225,13 +226,22 @@ class LogArea:
         :type log: str
         :param name: Name of file to upload.
         :type name: str
-        :param folder: Folder to upload to.
-        :type folder: str
+        :param main_suite_id: Main suite ID for folder creation.
+        :type main_suite_id: str
+        :param sub_suite_id: Sub suite ID for folder creation.
+        :type sub_suite_id: str
         :return: URI where log was uploaded to.
         :rtype: str
         """
         upload = deepcopy(self.log_area.get("upload"))
-        data = {"context": context, "name": name, "folder": folder}
+        folder = f"{main_suite_id}/{sub_suite_id}"
+        data = {
+            "context": context,
+            "name": name,
+            "sub_suite_id": sub_suite_id,
+            "main_suite_id": main_suite_id,
+            "folder": folder
+        }
 
         # ETOS Library, for some reason, uses the key 'verb' instead of 'method'
         # for HTTP method.

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -19,6 +19,7 @@ import os
 import logging
 from pprint import pprint
 
+from eiffellib.events import EiffelTestSuiteStartedEvent
 from etos_test_runner.lib.iut_monitoring import IutMonitoring
 from etos_test_runner.lib.executor import Executor
 from etos_test_runner.lib.workspace import Workspace
@@ -59,17 +60,20 @@ class TestRunner:
         categories.append(self.iut.identity.name)
         livelogs = self.config.get("log_area", {}).get("livelogs")
 
+        test_suite_started = EiffelTestSuiteStartedEvent()
+        data = {
+            "name": suite_name,
+            "categories": categories,
+            "types": ["FUNCTIONAL"],
+            "liveLogs": [{"name": "console", "uri": livelogs}]
+        }
         # TODO: Remove CONTEXT link here.
-        return self.etos.events.send_test_suite_started(
-            suite_name,
-            links={
-                "CONTEXT": self.etos.config.get("context"),
-                "CAUSE": self.etos.config.get("main_suite_id"),
-            },
-            categories=categories,
-            types=["FUNCTIONAL"],
-            liveLogs=[{"name": "console", "uri": livelogs}],
-        )
+        links={
+            "CONTEXT": self.etos.config.get("context"),
+            "CAUSE": self.etos.config.get("main_suite_id"),
+        }
+        test_suite_started.meta.event_id = self.config.get("sub_suite_id")
+        return self.etos.events.send(test_suite_started, links, data)
 
     def environment(self, context):
         """Send out which environment we're executing within.


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
We also get the sub suite ID from the environment provider instead of generating our own. This is so that the sub suite ID can be available before starting up the ETR, such as in the new log area API.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
Lots. This was the simplest one I think. We should probably go over ETOS and make sure we make more information available via ETCD.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
