### PR TITLE
Enable user logs in ETR

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ package_dir =
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 install_requires =
-    etos_lib==3.2.2
+    etos_lib==4.3.6
     cryptography>=42.0.4,<43.0.0
     packageurl-python==0.9.1
     jsontas==1.3.0

--- a/src/etos_test_runner/__init__.py
+++ b/src/etos_test_runner/__init__.py
@@ -18,18 +18,26 @@ import os
 import logging
 from importlib.metadata import version, PackageNotFoundError
 from etos_lib.logging.logger import setup_logging
+from etos_test_runner.lib.decrypt import decrypt
 
 try:
     VERSION = version("etos_test_runner")
 except PackageNotFoundError:
     VERSION = "Unknown"
 
-# Disable sending logs for now.
-os.environ["ETOS_ENABLE_SENDING_LOGS"] = "false"
+if os.getenv("ETOS_ENCRYPTION_KEY"):
+    os.environ["ETOS_RABBITMQ_PASSWORD"] = decrypt(
+        os.environ["ETOS_RABBITMQ_PASSWORD"], os.getenv("ETOS_ENCRYPTION_KEY")
+    )
 
 DEV = os.getenv("DEV", "false").lower() == "true"
 ENVIRONMENT = "development" if DEV else "production"
 setup_logging("ETOS Test Runner", VERSION, ENVIRONMENT)
+
+# ETR will print the entire environment just before executing.
+# Hide the password.
+os.environ["ETOS_RABBITMQ_PASSWORD"] = "*********"
+
 # JSONTas would print all passwords as they are decrypted,
 # which is not safe, so we disable propagation on the loggers.
 # Propagation needs to be set to 0 instead of disabling the

--- a/src/etos_test_runner/etr.py
+++ b/src/etos_test_runner/etr.py
@@ -93,10 +93,8 @@ class ETR:
         :param sub_suite_url: URL to where the sub suite information exists.
         :type sub_suite_url: str
         """
-        generator = self.etos.http.wait_for_request(sub_suite_url, as_json=False)
-        for response in generator:
-            json_config = response.json(object_pairs_hook=OrderedDict)
-            break
+        response = self.etos.http.get(sub_suite_url)
+        json_config = response.json(object_pairs_hook=OrderedDict)
         dataset = CustomDataset()
         dataset.add("decrypt", Decrypt)
         config = JsonTas(dataset).run(json_config)

--- a/src/etos_test_runner/lib/log_area.py
+++ b/src/etos_test_runner/lib/log_area.py
@@ -305,7 +305,12 @@ class LogArea:
                 # Seek back to the start of the file so that the uploaded file
                 # is not 0 bytes in size.
                 log_file.seek(0)
-                yield self.etos.http.request(verb, url, as_json, data=log_file, **requests_kwargs)
+                request = getattr(self.etos.http, verb.lower())
+                response = request(url, data=log_file, **requests_kwargs).json()
+                if as_json:
+                    yield response.json()
+                else:
+                    yield response
                 break
             except (
                 ConnectionError,

--- a/src/etos_test_runner/lib/log_area.py
+++ b/src/etos_test_runner/lib/log_area.py
@@ -306,7 +306,7 @@ class LogArea:
                 # is not 0 bytes in size.
                 log_file.seek(0)
                 request = getattr(self.etos.http, verb.lower())
-                response = request(url, data=log_file, **requests_kwargs).json()
+                response = request(url, data=log_file, **requests_kwargs)
                 if as_json:
                     yield response.json()
                 else:


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
eiffel-community/etos#103

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Enable user log sending for the ETR. This will require an update to the environment provider so that the right environment variables are also being sent. This change is required for us to send log and artifact URLs from the ETR to the client.
I had to update ETOS library which required an update to the HTTP requests

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
None.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
