### PR TITLE
Migrate container images to ghcr.io

### DIFF
--- a/tests/scenarios/test_full_execution.py
+++ b/tests/scenarios/test_full_execution.py
@@ -60,7 +60,7 @@ SUITE = {
                 {"key": "COMMAND", "value": "/bin/bash ./test.sh"},
                 {
                     "key": "TEST_RUNNER",
-                    "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                    "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                 },
                 {"key": "EXECUTE", "value": ["echo 'this is the pre-execution step'"]},
                 {
@@ -79,7 +79,7 @@ SUITE = {
             },
         }
     ],
-    "test_runner": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+    "test_runner": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
     "iut": {
         "provider_id": "default",
         "identity": "pkg:docker/production/etos/etos-api@1.2.0",

--- a/tests/scenarios/test_log_upload.py
+++ b/tests/scenarios/test_log_upload.py
@@ -44,7 +44,7 @@ SUITE = {
                 {"key": "COMMAND", "value": "exit 0"},
                 {
                     "key": "TEST_RUNNER",
-                    "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                    "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                 },
                 {"key": "EXECUTE", "value": ["echo 'this is the pre-execution step'"]},
                 {
@@ -60,7 +60,7 @@ SUITE = {
             },
         }
     ],
-    "test_runner": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+    "test_runner": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
     "iut": {
         "provider_id": "default",
         "identity": "pkg:docker/production/etos/etos-api@1.2.0",

--- a/tests/scenarios/test_no_detected_test_name.py
+++ b/tests/scenarios/test_no_detected_test_name.py
@@ -60,7 +60,7 @@ SUITE = {
                 {"key": "COMMAND", "value": "/bin/bash ./test.sh"},
                 {
                     "key": "TEST_RUNNER",
-                    "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                    "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                 },
                 {"key": "EXECUTE", "value": ["echo 'this is the pre-execution step'"]},
                 {
@@ -79,7 +79,7 @@ SUITE = {
             },
         }
     ],
-    "test_runner": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+    "test_runner": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
     "iut": {
         "provider_id": "default",
         "identity": "pkg:docker/production/etos/etos-api@1.2.0",


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/343

### Description of the Change
This change changes ETOS  container references `nordix.org/eiffel` to `ghcr.io/eiffel-community`.


### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Andrei Matveyeu, andrei.matveyeu@axis.com