### PR TITLE
safer logic in log filename truncation

### DIFF
--- a/src/etos_test_runner/lib/log_area.py
+++ b/src/etos_test_runner/lib/log_area.py
@@ -88,10 +88,28 @@ class LogArea:
             filename = f"{prepend}{join_character}{filename}"
             self.logger.info("Result: %r", filename)
         if len(filename) + 5 > 255:  # +5 as to be able to prepend counter.
+            max_length = 250
             self.logger.info(
-                "Filename is too long at %r. Reduce size to %r.", len(filename) + 5, 250
+                "Filename is too long at %r. Reduce size to %r.", len(filename) + 5, max_length
             )
-            filename = filename[: 250 - len(path.suffix)] + path.suffix
+            # Split filename into base and extension
+            if "." in filename:
+                base, suffix = filename.rsplit(".", 1)
+            else:
+                base, suffix = filename, ""
+
+            # Remove trailing dots to avoid double dots (e.g., "file..txt")
+            base_clean = base.rstrip(".")
+
+            # Calculate max length for base part
+            # max_length total - extension length - 1 for dot (if extension exists)
+            if suffix:
+                max_base_length = max_length - len(suffix) - 1
+                truncated_base = base_clean[:max_base_length]
+                filename = f"{truncated_base}.{suffix}"
+            else:
+                truncated_base = base_clean[:max_length]
+                filename = truncated_base
             self.logger.info("Result: %r", filename)
         log_names = [item["name"] for item in self.logs + self.artifacts]
         index = 0


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/425

### Description of the Change
This change introduces a filename truncation logic that is aware of filename structure (base name / extension).

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Andrei Matveyeu, andrei.matveyeu@axis.com