### PR TITLE
prevent log gz archives from having double dots

### DIFF
--- a/src/etos_test_runner/lib/log_area.py
+++ b/src/etos_test_runner/lib/log_area.py
@@ -132,8 +132,10 @@ class LogArea:
         self.logger.info("Collecting logs/artifacts for %r", test_name or "global")
         for item in path.iterdir():
             if item.is_dir():
+                # Clean the archive name to avoid double dots when make_archive appends .tar.gz
+                archive_name = str(item.relative_to(Path.cwd())).rstrip(".")
                 compressed_item = make_archive(
-                    item.relative_to(Path.cwd()),
+                    archive_name,
                     format="gztar",
                     root_dir=path,
                     base_dir=item.name,


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/425

### Description of the Change
The change adds handling for the case when double dots are added by the `collect()` method, i. e. when creating a `.gz` archive.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com