### PR TITLE
lib/log_area.py: more robust truncation of long filenames

### DIFF
--- a/src/etos_test_runner/lib/log_area.py
+++ b/src/etos_test_runner/lib/log_area.py
@@ -105,10 +105,10 @@ class LogArea:
             # max_length total - extension length - 1 for dot (if extension exists)
             if suffix:
                 max_base_length = max_length - len(suffix) - 1
-                truncated_base = base_clean[:max_base_length]
+                truncated_base = base_clean[:max_base_length].rstrip(".")
                 filename = f"{truncated_base}.{suffix}"
             else:
-                truncated_base = base_clean[:max_length]
+                truncated_base = base_clean[:max_length].rstrip(".")
                 filename = truncated_base
             self.logger.info("Result: %r", filename)
         log_names = [item["name"] for item in self.logs + self.artifacts]


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/425

### Description of the Change
This change is needed for cases where truncating the base name to the maximum length leaves a dot at the end. Removing trailing dots after truncation prevents filenames like "file..txt". The previous PR did not fully fix the problem: https://github.com/eiffel-community/etos-test-runner/pull/58

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com