### PR TITLE
Fix a problem where ETR would not respect quotation marks

### DIFF
--- a/src/etos_test_runner/__init__.py
+++ b/src/etos_test_runner/__init__.py
@@ -14,16 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS test runner module."""
+
 import os
 import logging
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import version as _version, PackageNotFoundError
 from etos_lib.logging.logger import setup_logging
 from etos_test_runner.lib.decrypt import decrypt
 
 try:
-    VERSION = version("etos_test_runner")
+    version = _version("etos_test_runner")
 except PackageNotFoundError:
-    VERSION = "Unknown"
+    version = "Unknown"
 
 if os.getenv("ETOS_ENCRYPTION_KEY"):
     os.environ["ETOS_RABBITMQ_PASSWORD"] = decrypt(
@@ -32,7 +33,7 @@ if os.getenv("ETOS_ENCRYPTION_KEY"):
 
 DEV = os.getenv("DEV", "false").lower() == "true"
 ENVIRONMENT = "development" if DEV else "production"
-setup_logging("ETOS Test Runner", VERSION, ENVIRONMENT)
+setup_logging("ETOS Test Runner", version, ENVIRONMENT)
 
 # JSONTas would print all passwords as they are decrypted,
 # which is not safe, so we disable propagation on the loggers.

--- a/src/etos_test_runner/__init__.py
+++ b/src/etos_test_runner/__init__.py
@@ -17,14 +17,16 @@
 
 import os
 import logging
-from importlib.metadata import version as _version, PackageNotFoundError
+from importlib.metadata import version, PackageNotFoundError
+
 from etos_lib.logging.logger import setup_logging
+
 from etos_test_runner.lib.decrypt import decrypt
 
 try:
-    version = _version("etos_test_runner")
+    VERSION = version("etos_test_runner")
 except PackageNotFoundError:
-    version = "Unknown"
+    VERSION = "Unknown"
 
 if os.getenv("ETOS_ENCRYPTION_KEY"):
     os.environ["ETOS_RABBITMQ_PASSWORD"] = decrypt(
@@ -33,7 +35,7 @@ if os.getenv("ETOS_ENCRYPTION_KEY"):
 
 DEV = os.getenv("DEV", "false").lower() == "true"
 ENVIRONMENT = "development" if DEV else "production"
-setup_logging("ETOS Test Runner", version, ENVIRONMENT)
+setup_logging("ETOS Test Runner", VERSION, ENVIRONMENT)
 
 # JSONTas would print all passwords as they are decrypted,
 # which is not safe, so we disable propagation on the loggers.

--- a/src/etos_test_runner/lib/executor.sh
+++ b/src/etos_test_runner/lib/executor.sh
@@ -17,21 +17,21 @@
 eval "$(pyenv init -)"
 pyenv shell --unset
 
-DIR=$(dirname $0)
+DIR="$(dirname "$0")"
 echo "Executing pre-execution script"
-cat $DIR/environ.sh
-if ! source $DIR/environ.sh ; then
+cat "$DIR/environ.sh"
+if ! source "$DIR/environ.sh" ; then
     echo Could not execute pre-execution script.
     exit 1
 fi
 
 COMMAND=$1
 shift
-ARGS=$@
+ARGS=("$@")
 
 echo "Environment used for tests"
 env | sort
 
 echo "Executing:"
-echo $COMMAND $ARGS
-$COMMAND $ARGS
+echo "$COMMAND" "${ARGS[@]}"
+"$COMMAND" "${ARGS[@]}"

--- a/tests/scenarios/test_full_execution.py
+++ b/tests/scenarios/test_full_execution.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests full executions."""
+
 import logging
 import os
 from contextlib import contextmanager
@@ -33,6 +34,7 @@ TEST = """#!/bin/bash
 echo ==== test_name_yo ====
 echo == STARTED ==
 echo == PASSED ==
+
 exit 0
 """
 
@@ -96,7 +98,7 @@ SUITE = {
     "log_area": {
         "provider_id": "default",
         "livelogs": "http://localhost/livelogs",
-        "upload": {"url": "http://localhost/logs", "method": "POST"},
+        "upload": {"url": "http://localhost/logs", "method": "PUT", "as_json": False},
         "logs": {},
     },
 }

--- a/tests/scenarios/test_no_detected_test_name.py
+++ b/tests/scenarios/test_no_detected_test_name.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests full executions."""
+
 import logging
 import os
 from contextlib import contextmanager
@@ -96,7 +97,7 @@ SUITE = {
     "log_area": {
         "provider_id": "default",
         "livelogs": "http://localhost/livelogs",
-        "upload": {"url": "http://localhost/logs", "method": "POST"},
+        "upload": {"url": "http://localhost/logs", "method": "PUT", "as_json": False},
         "logs": {},
     },
 }

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
 deps =
     black
 commands =
-    black --check --diff -l 100 .
+    black --check --diff -l 100 src tests
 
 [testenv:pylint]
 deps =
@@ -34,4 +34,4 @@ commands =
 deps =
     pydocstyle
 commands =
-    pydocstyle .
+    pydocstyle src tests


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
N/A

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Make sure we get the input parameters as an array instead of "mushing" them into a string. This makes sure that all parameters are sent to the $COMMAND as they were passed to the executor.sh script, making the script more robust.
When debugging this problem I ran a tool called `shellcheck` which gave some comments on the script that I fixed as well.

I noticed that a few tests threw a ton of errors in the logs (without failing the tests) that I fixed and I also had to fix a few things that failed when running tox.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
None!

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
This is a change in behavior. It should be more robust, but we don't know if there are any users that depend on the flaky behavior that we have now. We need to test this rigorously and it should be a major release tag on ETOS.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
