### PR TITLE
Run plugin suite_finished handler before upload

### DIFF
--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -227,7 +227,7 @@ class TestRunner:
         for plugin in self.plugins:
             plugin.on_test_suite_finished(name, outcome)
 
-    def _run_and_finalize(self, workspace):
+    def _run_and_finalize(self, workspace: Workspace) -> None:
         """Run tests and finalize outcome before artifact upload.
 
         Must be called inside a Workspace context so that plugin handlers

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -248,6 +248,8 @@ class TestRunner:
         outcome = None
         try:
             with Workspace(self.log_area) as workspace:
+                # Inner try/finally ensures plugin handlers run before
+                # Workspace.__exit__ uploads artifacts.
                 try:
                     self.logger.info("Start IUT monitoring.")
                     self.iut_monitoring.start_monitoring()

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -245,24 +245,32 @@ class TestRunner:
         description = None
         executed = False
         test_framework_exit_codes = []
+        outcome = None
         try:
             with Workspace(self.log_area) as workspace:
-                self.logger.info("Start IUT monitoring.")
-                self.iut_monitoring.start_monitoring()
-                self.logger.info("Starting test executor.")
-                result, test_framework_exit_codes = self.run_tests(workspace)
-                executed = True
-                self.logger.info("Stop IUT monitoring.")
-                self.iut_monitoring.stop_monitoring()
-        except Exception as exception:  # pylint:disable=broad-except
-            result = False
-            executed = False
-            description = str(exception)
-            raise
+                try:
+                    self.logger.info("Start IUT monitoring.")
+                    self.iut_monitoring.start_monitoring()
+                    self.logger.info("Starting test executor.")
+                    result, test_framework_exit_codes = self.run_tests(workspace)
+                    executed = True
+                    self.logger.info("Stop IUT monitoring.")
+                    self.iut_monitoring.stop_monitoring()
+                except Exception as exception:  # pylint:disable=broad-except
+                    result = False
+                    executed = False
+                    description = str(exception)
+                    raise
+                finally:
+                    if self.iut_monitoring.monitoring:
+                        self.logger.info("Stop IUT monitoring.")
+                        self.iut_monitoring.stop_monitoring()
+                    self.logger.info("Figure out test outcome.")
+                    outcome = self.outcome(result, executed, description, test_framework_exit_codes)
+                    pprint(outcome)
+                    self.logger.info("Call on_test_suite_finished plugin handlers.")
+                    self._test_suite_finished(self.config.get("name"), outcome)
         finally:
-            if self.iut_monitoring.monitoring:
-                self.logger.info("Stop IUT monitoring.")
-                self.iut_monitoring.stop_monitoring()
             self.logger.info(
                 "Log area upload finished. Total uploaded: %d (%d log(s), %d artifact(s))",
                 len(self.log_area.logs) + len(self.log_area.artifacts),
@@ -270,12 +278,11 @@ class TestRunner:
                 len(self.log_area.artifacts),
                 extra={"user_log": True},
             )
-            self.logger.info("Figure out test outcome.")
-            outcome = self.outcome(result, executed, description, test_framework_exit_codes)
-            pprint(outcome)
-
+            if outcome is None:
+                self.logger.info("Figure out test outcome.")
+                outcome = self.outcome(result, executed, description, test_framework_exit_codes)
+                pprint(outcome)
             self.logger.info("Send test suite finished event.")
-            self._test_suite_finished(self.config.get("name"), outcome)
             test_suite_finished = self.etos.events.send_test_suite_finished(
                 test_suite_started,
                 links={"CONTEXT": self.etos.config.get("context")},

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -54,6 +54,8 @@ class TestRunner:
         self.issuer = {"name": "ETOS Test Runner"}
         self.etos.config.set("iut", self.iut)
         self.plugins = self.etos.config.get("plugins")
+        self._result = True
+        self._outcome = None
 
         verdict_rule_file = os.getenv("VERDICT_RULES_FILE")
         if verdict_rule_file is not None:
@@ -225,6 +227,47 @@ class TestRunner:
         for plugin in self.plugins:
             plugin.on_test_suite_finished(name, outcome)
 
+    def _run_and_finalize(self, workspace):
+        """Run tests and finalize outcome before artifact upload.
+
+        Must be called inside a Workspace context so that plugin handlers
+        can create artifacts that get uploaded by Workspace.__exit__.
+
+        Stores result and outcome on ``self`` so that they are available
+        to the caller even when an exception propagates.
+
+        :param workspace: Active workspace context.
+        :type workspace: :obj:`etr.lib.workspace.Workspace`
+        """
+        self._result = True
+        description = None
+        executed = False
+        test_framework_exit_codes = []
+        try:
+            self.logger.info("Start IUT monitoring.")
+            self.iut_monitoring.start_monitoring()
+            self.logger.info("Starting test executor.")
+            self._result, test_framework_exit_codes = self.run_tests(workspace)
+            executed = True
+            self.logger.info("Stop IUT monitoring.")
+            self.iut_monitoring.stop_monitoring()
+        except Exception as exception:  # pylint:disable=broad-except
+            self._result = False
+            executed = False
+            description = str(exception)
+            raise
+        finally:
+            if self.iut_monitoring.monitoring:
+                self.logger.info("Stop IUT monitoring.")
+                self.iut_monitoring.stop_monitoring()
+            self.logger.info("Figure out test outcome.")
+            self._outcome = self.outcome(
+                self._result, executed, description, test_framework_exit_codes
+            )
+            pprint(self._outcome)
+            self.logger.debug("Call on_test_suite_finished plugin handlers.")
+            self._test_suite_finished(self.config.get("name"), self._outcome)
+
     def execute(self):  # pylint:disable=too-many-branches,disable=too-many-statements
         """Execute all tests in test suite.
 
@@ -241,37 +284,11 @@ class TestRunner:
         self.environment(sub_suite_id)
         self.etos.config.set("sub_suite_id", sub_suite_id)
 
-        result = True
-        description = None
-        executed = False
-        test_framework_exit_codes = []
-        outcome = None
+        self._result = True
+        self._outcome = None
         try:
             with Workspace(self.log_area) as workspace:
-                # Inner try/finally ensures plugin handlers run before
-                # Workspace.__exit__ uploads artifacts.
-                try:
-                    self.logger.info("Start IUT monitoring.")
-                    self.iut_monitoring.start_monitoring()
-                    self.logger.info("Starting test executor.")
-                    result, test_framework_exit_codes = self.run_tests(workspace)
-                    executed = True
-                    self.logger.info("Stop IUT monitoring.")
-                    self.iut_monitoring.stop_monitoring()
-                except Exception as exception:  # pylint:disable=broad-except
-                    result = False
-                    executed = False
-                    description = str(exception)
-                    raise
-                finally:
-                    if self.iut_monitoring.monitoring:
-                        self.logger.info("Stop IUT monitoring.")
-                        self.iut_monitoring.stop_monitoring()
-                    self.logger.info("Figure out test outcome.")
-                    outcome = self.outcome(result, executed, description, test_framework_exit_codes)
-                    pprint(outcome)
-                    self.logger.debug("Call on_test_suite_finished plugin handlers.")
-                    self._test_suite_finished(self.config.get("name"), outcome)
+                self._run_and_finalize(workspace)
         finally:
             self.logger.info(
                 "Log area upload finished. Total uploaded: %d (%d log(s), %d artifact(s))",
@@ -280,15 +297,15 @@ class TestRunner:
                 len(self.log_area.artifacts),
                 extra={"user_log": True},
             )
-            if outcome is None:
+            if self._outcome is None:
                 self.logger.info("Figure out test outcome.")
-                outcome = self.outcome(result, executed, description, test_framework_exit_codes)
-                pprint(outcome)
+                self._outcome = self.outcome(self._result, False, None, [])
+                pprint(self._outcome)
             self.logger.info("Send test suite finished event.")
             test_suite_finished = self.etos.events.send_test_suite_finished(
                 test_suite_started,
                 links={"CONTEXT": self.etos.config.get("context")},
-                outcome=outcome,
+                outcome=self._outcome,
                 persistentLogs=self.log_area.persistent_logs,
             )
             self.logger.info(test_suite_finished.pretty)
@@ -314,4 +331,4 @@ class TestRunner:
             previous = current
             time.sleep(1)
         self.logger.info("Tests finished executing.")
-        return 0 if result else outcome
+        return 0 if self._result else self._outcome

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -268,7 +268,7 @@ class TestRunner:
                     self.logger.info("Figure out test outcome.")
                     outcome = self.outcome(result, executed, description, test_framework_exit_codes)
                     pprint(outcome)
-                    self.logger.info("Call on_test_suite_finished plugin handlers.")
+                    self.logger.debug("Call on_test_suite_finished plugin handlers.")
                     self._test_suite_finished(self.config.get("name"), outcome)
         finally:
             self.logger.info(


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/504

### Description of the Change

Move the `on_test_suite_finished` plugin handler call to run before the Workspace context manager exits, which is where artifact upload happens. Previously the handler ran after artifacts were already uploaded, so plugins that needed to create additional artifacts upon suite completion had to handle upload themselves. Now plugins can simply write files to the artifact directory and they will be uploaded automatically.

### Alternate Designs



### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com