### PR TITLE
Update GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.13"
     - name: Install pypa/build
@@ -24,7 +24,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: python-package-distributions
         path: dist/
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under , so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Install Tox
@@ -34,9 +34,9 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Install pypa/build

--- a/.github/workflows/update-etos.yaml
+++ b/.github/workflows/update-etos.yaml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Generate a token
       id: generate-token
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@v3
       with:
         owner: ${{ env.REPOSITORY_OWNER }}
         repositories: ${{ env.ETOS_REPOSITORY }}
@@ -35,7 +35,7 @@ jobs:
         repository: ${{ env.REPOSITORY_OWNER }}/${{ env.ETOS_REPOSITORY }}
         token: ${{ steps.generate-token.outputs.token }}
     - name: Update manifests
-      uses: fjogeleit/yaml-update-action@main
+      uses: fjogeleit/yaml-update-action@v0.16.1
       with:
         commitChange: false
         token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Applicable Issues

https://github.com/eiffel-community/etos/issues/595

### Description of the Change

Update 3 workflow files: checkout v4→v6, setup-python v4→v6, upload-artifact v4→v6, download-artifact v4→v7, create-github-app-token v2→v3, and fjogeleit/yaml-update-action main→v0.16.1.

### Alternate Designs

_No response_

### Possible Drawbacks

Note: `fjogeleit/yaml-update-action` is pinned to v0.16.1 (still node20) as no node24-compatible release exists yet.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com