### PR TITLE
Remove pyenv dependency, add TEST_FRAMEWORK_VENV support

### DIFF
--- a/src/etos_test_runner/lib/executor.py
+++ b/src/etos_test_runner/lib/executor.py
@@ -142,8 +142,12 @@ class Executor:  # pylint:disable=too-many-instance-attributes
         test_directory_name = Path().absolute().name
         checkout = workspace.joinpath(f"checkout_{test_directory_name}.sh")
         with checkout.open(mode="w", encoding="utf-8") as checkout_file:
-            checkout_file.write('eval "$(pyenv init -)"\n')
-            checkout_file.write("pyenv shell --unset\n")
+            checkout_file.write(
+                'if [ -n "$TEST_FRAMEWORK_VENV" ] && '
+                '[ -f "$TEST_FRAMEWORK_VENV/bin/activate" ]; then\n'
+                '    source "$TEST_FRAMEWORK_VENV/bin/activate"\n'
+                "fi\n"
+            )
             for command in test_checkout:
                 checkout_file.write(f"{command} || exit 1\n")
 

--- a/src/etos_test_runner/lib/executor.py
+++ b/src/etos_test_runner/lib/executor.py
@@ -146,6 +146,9 @@ class Executor:  # pylint:disable=too-many-instance-attributes
                 'if [ -n "$TEST_FRAMEWORK_VENV" ] && '
                 '[ -f "$TEST_FRAMEWORK_VENV/bin/activate" ]; then\n'
                 '    source "$TEST_FRAMEWORK_VENV/bin/activate"\n'
+                "elif command -v pyenv &>/dev/null; then\n"
+                '    eval "$(pyenv init -)"\n'
+                "    pyenv shell --unset\n"
                 "fi\n"
             )
             for command in test_checkout:

--- a/src/etos_test_runner/lib/executor.sh
+++ b/src/etos_test_runner/lib/executor.sh
@@ -16,8 +16,8 @@
 # limitations under the License.
 
 # Activate test virtual environment if configured.
-# Containers that use a separate virtualenv for test dependencies (e.g. pytest
-# plugins) can set TEST_FRAMEWORK_VENV to that venv path.
+# Containers that use a separate virtualenv for test dependencies
+# can set TEST_FRAMEWORK_VENV to that venv path.
 if [ -n "$TEST_FRAMEWORK_VENV" ] && [ -f "$TEST_FRAMEWORK_VENV/bin/activate" ]; then
     source "$TEST_FRAMEWORK_VENV/bin/activate"
 fi

--- a/src/etos_test_runner/lib/executor.sh
+++ b/src/etos_test_runner/lib/executor.sh
@@ -14,8 +14,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-eval "$(pyenv init -)"
-pyenv shell --unset
+
+# Activate test virtual environment if configured.
+# Containers that use a separate virtualenv for test dependencies (e.g. pytest
+# plugins) can set TEST_FRAMEWORK_VENV to that venv path.
+if [ -n "$TEST_FRAMEWORK_VENV" ] && [ -f "$TEST_FRAMEWORK_VENV/bin/activate" ]; then
+    source "$TEST_FRAMEWORK_VENV/bin/activate"
+fi
 
 DIR="$(dirname "$0")"
 echo "Executing pre-execution script"

--- a/src/etos_test_runner/lib/executor.sh
+++ b/src/etos_test_runner/lib/executor.sh
@@ -18,8 +18,12 @@
 # Activate test virtual environment if configured.
 # Containers that use a separate virtualenv for test dependencies
 # can set TEST_FRAMEWORK_VENV to that venv path.
+# Falls back to pyenv for backward compatibility with older base images.
 if [ -n "$TEST_FRAMEWORK_VENV" ] && [ -f "$TEST_FRAMEWORK_VENV/bin/activate" ]; then
     source "$TEST_FRAMEWORK_VENV/bin/activate"
+elif command -v pyenv &>/dev/null; then
+    eval "$(pyenv init -)"
+    pyenv shell --unset
 fi
 
 DIR="$(dirname "$0")"


### PR DESCRIPTION
### Applicable Issues

https://github.com/eiffel-community/etos/issues/672

### Description of the Change

Remove pyenv references from executor.sh and executor.py and add a generic `TEST_FRAMEWORK_VENV` environment variable that activates a separate virtualenv for test execution.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com