### PR TITLE
Support the v1beta1 version of ETOS environments

### DIFF
--- a/src/etos_test_runner/etr.py
+++ b/src/etos_test_runner/etr.py
@@ -30,8 +30,9 @@ from pprint import pprint
 from typing import Optional, Union
 
 from etos_lib import ETOS
-from etos_lib.kubernetes.schemas.v1beta1.environment import \
-    EnvironmentSpec as V1Beta1EnvironmentSpec
+from etos_lib.kubernetes.schemas.v1beta1.environment import (
+    EnvironmentSpec as V1Beta1EnvironmentSpec,
+)
 from etos_lib.lib.http import Http
 from etos_lib.logging.logger import FORMAT_CONFIG
 from etos_lib.messaging.events import Status
@@ -128,7 +129,8 @@ class ETR:
         if os.getenv("ETOS_ENCRYPTION_KEY"):
             os.environ["ETOS_ENCRYPTION_KEY"] = "*********"
 
-        # test_config kept for backward compatibility with plugins, but should not be used by ETR itself.
+        # test_config kept for backward compatibility with plugins, but should not be used by
+        # ETR itself.
         self.etos.config.set("test_config", config)
 
         self.etos.config.set("suite", suite)

--- a/src/etos_test_runner/etr.py
+++ b/src/etos_test_runner/etr.py
@@ -18,6 +18,7 @@
 """ETOS test runner module."""
 
 import importlib
+import json
 import logging
 import os
 import pkgutil
@@ -29,12 +30,17 @@ from pprint import pprint
 from typing import Optional, Union
 
 from etos_lib import ETOS
+from etos_lib.kubernetes.schemas.v1beta1.environment import \
+    EnvironmentSpec as V1Beta1EnvironmentSpec
 from etos_lib.lib.http import Http
 from etos_lib.logging.logger import FORMAT_CONFIG
 from etos_lib.messaging.events import Status
 from etos_lib.messaging.types import ServiceHealth, ServiceStatus
+from etos_lib.schemas.v0.environment import Suite as V0Suite
 from jsontas.jsontas import JsonTas
+from pydantic import ValidationError
 from urllib3.util import Retry
+from yaml import safe_load
 
 from etos_test_runner.lib.custom_dataset import CustomDataset
 from etos_test_runner.lib.decrypt import Decrypt, decrypt
@@ -82,7 +88,7 @@ class ETR:
         """Catch sigterm."""
         raise Exception("ETR has been terminated.")  # pylint:disable=broad-exception-raised
 
-    def download_and_load(self, sub_suite_url: str) -> None:
+    def download_and_load(self, sub_suite_url: str) -> V1Beta1EnvironmentSpec:
         """Download and load test json.
 
         :param sub_suite_url: URL to where the sub suite information exists.
@@ -102,21 +108,35 @@ class ETR:
         http_client = Http(retry=retry)
 
         response = http_client.get(sub_suite_url)
-        json_config = response.json(object_pairs_hook=OrderedDict)
+        try:
+            json_config = response.json(object_pairs_hook=OrderedDict)
+        except json.JSONDecodeError:
+            testrun = safe_load(response.content)
+            json_config = OrderedDict(testrun)
         dataset = CustomDataset()
         dataset.add("decrypt", Decrypt)
         config = JsonTas(dataset).run(json_config)
+
+        try:
+            v0_suite = V0Suite(**config)
+            suite = V1Beta1EnvironmentSpec.convert_from(v0_suite)
+        except ValidationError:
+            suite = V1Beta1EnvironmentSpec(**config)
 
         # ETR will print the entire environment just before executing.
         # Hide the encryption key.
         if os.getenv("ETOS_ENCRYPTION_KEY"):
             os.environ["ETOS_ENCRYPTION_KEY"] = "*********"
 
+        # test_config kept for backward compatibility with plugins, but should not be used by ETR itself.
         self.etos.config.set("test_config", config)
-        self.etos.config.set("context", config.get("context"))
-        self.etos.config.set("artifact", config.get("artifact"))
-        self.etos.config.set("main_suite_id", config.get("test_suite_started_id"))
-        self.etos.config.set("suite_id", config.get("suite_id"))
+
+        self.etos.config.set("suite", suite)
+        self.etos.config.set("context", suite.context)
+        self.etos.config.set("artifact", suite.artifact)
+        self.etos.config.set("main_suite_id", suite.mainSuiteID)
+        self.etos.config.set("suite_id", suite.testrunID)
+        return suite
 
     def load_plugins(self) -> None:
         """Load plugins from environment using the name etr_."""
@@ -198,10 +218,10 @@ class ETR:
                     raise TimeoutError(
                         f"Could not get sub suite environment event with id {self.environment_id!r}"
                     )
-            self.download_and_load(sub_suite_url)
+            suite = self.download_and_load(sub_suite_url)
             FORMAT_CONFIG.identifier = self.etos.config.get("suite_id")
             self.load_plugins()
-            iut = Iut(self.etos.config.get("test_config").get("iut"))
+            iut = Iut(suite.iut)
             test_runner = TestRunner(iut, self.etos)
         except Exception as exception:  # pylint:disable=broad-except
             _LOGGER.exception("ETR failed to start.")

--- a/src/etos_test_runner/lib/executor.py
+++ b/src/etos_test_runner/lib/executor.py
@@ -26,6 +26,8 @@ from pathlib import Path
 from pprint import pprint
 from shutil import copy
 
+from etos_lib.kubernetes.schemas.v1beta1.environment import EnvironmentSpec
+
 BASE = Path(__file__).parent.absolute()
 
 
@@ -64,7 +66,7 @@ class Executor:  # pylint:disable=too-many-instance-attributes
         """Initialize.
 
         :param test: Test to execute.
-        :type test: str
+        :type test: :obj:`etos_lib.kubernetes.schemas.v1beta1.testrun.TestExecution`
         :param iut: IUT to execute test on.
         :type iut: :obj:`etr.lib.iut.Iut`
         :param etos: ETOS library instance.
@@ -74,30 +76,16 @@ class Executor:  # pylint:disable=too-many-instance-attributes
         self.test = test
         self.tests = {}
 
-        self.test_environment_variables = {}
-        self.test_command = None
-        self.pre_test_execution = []
-        self.test_command_input_arguments = {}
-        self.checkout_command = []
-
-        self.constraints = test.get("constraints", [])
-        for constraint in self.constraints:
-            if constraint.get("key") == "ENVIRONMENT":
-                self.test_environment_variables = constraint.get("value")
-            elif constraint.get("key") == "COMMAND":
-                self.test_command = constraint.get("value")
-            elif constraint.get("key") == "EXECUTE":
-                self.pre_test_execution = constraint.get("value")
-            elif constraint.get("key") == "PARAMETERS":
-                self.test_command_input_arguments = constraint.get("value")
-            elif constraint.get("key") == "CHECKOUT":
-                self.checkout_command = constraint.get("value")
-
-        self.test_name = test.get("testCase").get("id")
-        self.test_id = test.get("id")
-        self.iut = iut
         self.etos = etos
-        self.context = self.etos.config.get("context")
+        self.suite = self.etos.config.get("suite")
+        assert isinstance(
+            self.suite, EnvironmentSpec
+        ), "Suite config must be of type EnvironmentSpec"
+
+        self.test_name = test.testCase.id
+        self.test_id = test.id
+        self.iut = iut
+        self.context = self.suite.context
         self.plugins = self.etos.config.get("plugins")
         self.result = True
         self.returncode = None
@@ -176,17 +164,7 @@ class Executor:  # pylint:disable=too-many-instance-attributes
 
         self.logger.info("Executor script:\n %s", executor.read_text(encoding="utf-8"))
 
-        test_command = ""
-        parameters = []
-
-        for parameter, value in self.test_command_input_arguments.items():
-            if value == "":
-                parameters.append(parameter)
-            else:
-                parameters.append(f"{parameter}={value}")
-        parameters = " ".join(parameters)
-
-        test_command = f"./{executor} {self.test_command} {parameters} 2>&1"
+        test_command = f"./{executor} {self.test.execution.command} 2>&1"
         return test_command
 
     def __enter__(self):
@@ -221,9 +199,9 @@ class Executor:  # pylint:disable=too-many-instance-attributes
         """
         environments = [
             f"export {key}={shlex.quote(value)}"
-            for key, value in self.test_environment_variables.items()
+            for key, value in self.test.environment.environmentVariables.items()
         ]
-        return environments + self.pre_test_execution
+        return environments + self.test.execution.preExecution
 
     def _triggered(self, test_name):
         """Call on_test_case_triggered for all ETR plugins.
@@ -392,9 +370,9 @@ class Executor:  # pylint:disable=too-many-instance-attributes
         """
         line = False
         with workspace.test_directory(
-            " ".join(self.checkout_command),
+            " ".join(self.test.execution.checkout),
             self._checkout_tests,
-            self.checkout_command,
+            self.test.execution.checkout,
             workspace.workspace,
         ) as test_directory:
             self.report_path = test_directory.joinpath(f"logs/{self.report_path}")

--- a/src/etos_test_runner/lib/log_area.py
+++ b/src/etos_test_runner/lib/log_area.py
@@ -15,18 +15,20 @@
 # limitations under the License.
 """ETR log area handler."""
 
-import logging
-import traceback
 import hashlib
+import logging
 import time
+import traceback
 from copy import deepcopy
+from json.decoder import JSONDecodeError
 from pathlib import Path
 from shutil import make_archive, rmtree
-from json.decoder import JSONDecodeError
 
+from etos_lib.kubernetes.schemas.v1beta1.environment import EnvironmentSpec
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 from requests.exceptions import HTTPError
 from urllib3.exceptions import MaxRetryError, NewConnectionError
+
 from etos_test_runner.lib.events import EventPublisher
 
 
@@ -43,9 +45,11 @@ class LogArea:
         """
         self.etos = etos
         self.event_publisher = EventPublisher(etos)
-        self.identifier = self.etos.config.get("suite_id")
-        self.suite_name = self.etos.config.get("test_config").get("name").replace(" ", "-")
-        self.log_area = self.etos.config.get("test_config").get("log_area")
+        suite = self.etos.config.get("suite")
+        assert isinstance(suite, EnvironmentSpec), "Suite must be of type EnvironmentSpec"
+
+        self.suite_name = suite.name.replace(" ", "-")
+        self.log_area = suite.logArea
         self.logs = []
         self.artifacts = []
 

--- a/src/etos_test_runner/lib/testrunner.py
+++ b/src/etos_test_runner/lib/testrunner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Axis Communications AB.
+# Copyright Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -23,6 +23,7 @@ from pprint import pprint
 from typing import Union
 
 from eiffellib.events import EiffelTestSuiteStartedEvent
+from etos_lib.kubernetes.schemas.v1beta1.environment import EnvironmentSpec
 
 from etos_test_runner.lib.executor import Executor
 from etos_test_runner.lib.iut_monitoring import IutMonitoring
@@ -46,8 +47,11 @@ class TestRunner:
         """
         self.etos = etos
         self.iut = iut
-        self.config = self.etos.config.get("test_config")
-        self.logger = logging.getLogger(f"ETR - {self.config.get('name')}")
+        self.suite = self.etos.config.get("suite")
+        assert isinstance(
+            self.suite, EnvironmentSpec
+        ), "Suite config should be of type EnvironmentSpec"
+        self.logger = logging.getLogger(f"ETR - {self.suite.name}")
 
         self.log_area = LogArea(self.etos)
         self.iut_monitoring = IutMonitoring(self.iut, self.etos)
@@ -72,10 +76,10 @@ class TestRunner:
         :return: Reference to test suite started.
         :rtype: :obj:`eiffel.events.base_event.BaseEvent`
         """
-        suite_name = self.config.get("name")
+        suite_name = self.suite.name
         categories = ["Regression test_suite", "Sub suite"]
         categories.append(self.iut.identity.name)
-        livelogs = self.config.get("log_area", {}).get("livelogs")
+        livelogs = self.suite.logArea.get("livelogs")
 
         test_suite_started = EiffelTestSuiteStartedEvent()
         data = {
@@ -89,7 +93,7 @@ class TestRunner:
             "CONTEXT": self.etos.config.get("context"),
             "CAUSE": self.etos.config.get("main_suite_id"),
         }
-        test_suite_started.meta.event_id = self.config.get("sub_suite_id")
+        test_suite_started.meta.event_id = self.suite.id
         return self.etos.events.send(test_suite_started, links, data)
 
     def environment(self, context):
@@ -120,11 +124,10 @@ class TestRunner:
         :return: Result of test execution.
         :rtype: bool
         """
-        recipes = self.config.get("recipes")
         result = True
         test_framework_exit_codes = []
-        for num, test in enumerate(recipes):
-            self.logger.info("Executing test %s/%s", num + 1, len(recipes))
+        for num, test in enumerate(self.suite.testExecutions):
+            self.logger.info("Executing test %s/%s", num + 1, len(self.suite.testExecutions))
             with Executor(test, self.iut, self.etos) as executor:
                 self.logger.info("Starting test '%s'", executor.test_name, extra={"user_log": True})
                 executor.execute(workspace)
@@ -183,7 +186,7 @@ class TestRunner:
                 verdict,
             )
 
-        suite_name = self.config.get("name")
+        suite_name = self.suite.name
         if not description and not result:
             self.logger.info("No description but result is a failure. At least some tests failed.")
             description = f"At least some {suite_name} tests failed."
@@ -268,7 +271,7 @@ class TestRunner:
             )
             pprint(self._outcome)
             self.logger.debug("Call on_test_suite_finished plugin handlers.")
-            self._test_suite_finished(self.config.get("name"), self._outcome)
+            self._test_suite_finished(self.suite.name, self._outcome)
 
     def wait_for_events(self):
         """Wait for the Eiffel publisher to deliver all events."""
@@ -300,7 +303,7 @@ class TestRunner:
         """
         test_suite_started = None
         try:
-            self._test_suite_triggered(self.config.get("name"))
+            self._test_suite_triggered(self.suite.name)
             self.logger.info("Send test suite started event.")
             test_suite_started = self.test_suite_started()
             self._test_suite_started(test_suite_started)

--- a/tests/scenarios/test_full_execution.py
+++ b/tests/scenarios/test_full_execution.py
@@ -26,10 +26,8 @@ from unittest import TestCase
 
 from etos_lib.kubernetes.schemas.v1beta1.environment import EnvironmentSpec
 from etos_lib.kubernetes.schemas.v1beta1.testrun import Execution, Providers
-from etos_lib.kubernetes.schemas.v1beta1.testrun import \
-    TestCase as ETOSTestCase
-from etos_lib.kubernetes.schemas.v1beta1.testrun import (TestEnvironment,
-                                                         TestExecution)
+from etos_lib.kubernetes.schemas.v1beta1.testrun import TestCase as ETOSTestCase
+from etos_lib.kubernetes.schemas.v1beta1.testrun import TestEnvironment, TestExecution
 from etos_lib.lib.debug import Debug
 
 from etos_test_runner.etr import ETR

--- a/tests/scenarios/test_full_execution.py
+++ b/tests/scenarios/test_full_execution.py
@@ -24,6 +24,12 @@ from pathlib import Path
 from shutil import rmtree
 from unittest import TestCase
 
+from etos_lib.kubernetes.schemas.v1beta1.environment import EnvironmentSpec
+from etos_lib.kubernetes.schemas.v1beta1.testrun import Execution, Providers
+from etos_lib.kubernetes.schemas.v1beta1.testrun import \
+    TestCase as ETOSTestCase
+from etos_lib.kubernetes.schemas.v1beta1.testrun import (TestEnvironment,
+                                                         TestExecution)
 from etos_lib.lib.debug import Debug
 
 from etos_test_runner.etr import ETR
@@ -49,11 +55,12 @@ REGEX = """{
 }
 """
 
-SUITE = {
+V0_SUITE = {
     "name": "Test ETOS API scenario",
     "priority": 1,
     "test_suite_started_id": "577381ad-8356-4939-ab77-02e7abe06699",
     "sub_suite_id": "677381ad-8356-4939-ab77-02e7abe06688",
+    "suite_id": "439b201b-8759-4146-8e58-6704ecca6b9a",
     "recipes": [
         {
             "constraints": [
@@ -102,6 +109,61 @@ SUITE = {
         "logs": {},
     },
 }
+
+V1_SUITE = EnvironmentSpec(
+    name="Test ETOS API scenario",
+    id="677381ad-8356-4939-ab77-02e7abe06688",
+    testrunID="439b201b-8759-4146-8e58-6704ecca6b9a",
+    mainSuiteID="577381ad-8356-4939-ab77-02e7abe06699",
+    artifact="e9b0c120-8638-4c73-9b5c-e72226415ae6",
+    context="fde87097-46bd-4916-b69f-48dbbec47936",
+    providers=Providers(
+        iut="default-iut",
+        executionSpace="default-execution-space",
+        logArea="default-log-area",
+    ),
+    dataset={},
+    executor={},
+    iut={
+        "provider_id": "default",
+        "identity": "pkg:docker/production/etos/etos-api@1.2.0",
+        "type": "docker",
+        "namespace": "production/etos",
+        "name": "etos-api",
+        "version": "1.2.0",
+        "qualifiers": {},
+        "subpath": None,
+    },
+    logArea={
+        "provider_id": "default",
+        "livelogs": "http://localhost/livelogs",
+        "upload": {"url": "http://localhost/logs", "method": "PUT", "as_json": False},
+        "logs": {},
+    },
+    testRunner="ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
+    testExecutions=[
+        TestExecution(
+            id="6e8d29eb-4b05-4f5e-9207-0c94438479c7",
+            testCase=ETOSTestCase(
+                id="ETOS API functests",
+                tracker="Github",
+                url="https://github.com/eiffel-community/etos-api",
+            ),
+            execution=Execution(
+                command="/bin/bash ./test.sh",
+                preExecution=["echo 'this is the pre-execution step'"],
+                checkout=[
+                    "git clone https://github.com/eiffel-community/etos-test-runner.git .",
+                    f"cp {Path().joinpath('testfolder').absolute()}/test.sh .",
+                ],
+            ),
+            environment=TestEnvironment(
+                testRunner="ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
+                environmentVariables={},
+            ),
+        )
+    ],
+)
 
 
 # pylint:disable=too-many-instance-attributes
@@ -178,8 +240,8 @@ class TestFullExecution(TestCase):
             self.assertEqual(events.popleft().meta.type, event_name)
         self.assertEqual(list(events), [])
 
-    def test_full(self):
-        """Test that a full execution scenario works as expected.
+    def test_full_v0(self):
+        """Test that a full execution scenario using ETOS v0 works as expected.
 
         Approval criteria:
             - It shall be possible to execute a full suite in ETR.
@@ -200,11 +262,49 @@ class TestFullExecution(TestCase):
             "TEST_REGEX": str(self.regex.absolute()),
             "HOME": self.root,  # There is something weird with tox and HOME. This fixes it.
         }
-        suite = deepcopy(SUITE)
+        suite = deepcopy(V0_SUITE)
         handler = partial(Handler, suite)
         with self.environ(environment), FakeServer(handler) as server:
             os.environ["ETOS_GRAPHQL_SERVER"] = server.host
             suite["log_area"]["upload"]["url"] = f"{server.host}/{{name}}"
+            self.logger.info("STEP: Initialize and run ETR.")
+            etr = ETR()
+            result = etr.run_etr()
+
+            self.logger.info("STEP: Verify that events were sent in the correct order.")
+            self.validate_event_name_order(self.debug.events_published.copy())
+
+            self.logger.info("STEP: Verify that ETR returned with status code 0.")
+            # Result is either dictionary with outcome or an exit status code.
+            # Exit status code on success is 0
+            self.assertEqual(result, 0)
+
+    def test_full_v1(self):
+        """Test that a full execution scenario using ETOS v1 works as expected.
+
+        Approval criteria:
+            - It shall be possible to execute a full suite in ETR.
+            - ETR shall send events in the correct order.
+
+        Test steps::
+            1. Initialize and run ETR.
+            2. Verify that events were sent in the correct order.
+            3. Verify that ETR returned with status code 0.
+        """
+        environment = {
+            "ETOS_DISABLE_SENDING_EVENTS": "1",
+            "ETOS_DISABLE_RECEIVING_EVENTS": "1",
+            "ETOS_GRAPHQL_SERVER": "http://localhost/graphql",
+            "SUB_SUITE_URL": "http://localhost/download_suite",
+            "ENVIRONMENT_ID": "12345678-1234-5678-1234-567812345678",
+            "TEST_REGEX": str(self.regex.absolute()),
+            "HOME": self.root,  # There is something weird with tox and HOME. This fixes it.
+        }
+        suite = V1_SUITE.model_dump()
+        handler = partial(Handler, suite)
+        with self.environ(environment), FakeServer(handler) as server:
+            os.environ["ETOS_GRAPHQL_SERVER"] = server.host
+            suite["logArea"]["upload"]["url"] = f"{server.host}/{{name}}"
             self.logger.info("STEP: Initialize and run ETR.")
             etr = ETR()
             result = etr.run_etr()

--- a/tests/scenarios/test_log_upload.py
+++ b/tests/scenarios/test_log_upload.py
@@ -37,6 +37,7 @@ SUITE = {
     "priority": 1,
     "test_suite_started_id": "577381ad-8356-4939-ab77-02e7abe06699",
     "sub_suite_id": "677381ad-8356-4939-ab77-02e7abe06688",
+    "suite_id": "439b201b-8759-4146-8e58-6704ecca6b9a",
     "recipes": [
         {
             "constraints": [

--- a/tests/scenarios/test_no_detected_test_name.py
+++ b/tests/scenarios/test_no_detected_test_name.py
@@ -53,6 +53,7 @@ SUITE = {
     "priority": 1,
     "test_suite_started_id": "577381ad-8356-4939-ab77-02e7abe06699",
     "sub_suite_id": "677381ad-8356-4939-ab77-02e7abe06688",
+    "suite_id": "439b201b-8759-4146-8e58-6704ecca6b9a",
     "recipes": [
         {
             "constraints": [


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
eiffel-community/etos#661
depends-on: eiffel-community/etos-library#68

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
This change converts all environments (or sub suites) to the v1beta1 version of the EnvironmentSpec and updates the executor and testrunners to be able to run this version.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
I started by refactoring the entirety of the ETR to stop using the ETOS library config and instead pass around variables.
The change was good, but it created a much larger change than I think we want so I put that on the back-burner and instead focused on creating a change that works with the new format.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
One thing that I noticed, which is not really related to the ETR per-se, is that we pass a specific ETOS API version down to the ETR from the execution space providers. It is also expected that custom execution space providers know this and pass down the correct one as well. I don't have a solution yet and the solution might not be in the ETR.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
